### PR TITLE
async WASM function calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     docker:
       - image: circleci/elixir:1.9.1
         environment:
-            MIX_ENV: test
+          MIX_ENV: test
 
     working_directory: ~/repo
     steps:
@@ -17,8 +17,8 @@ jobs:
             - v1-dependency-cache-{{ checksum "mix.lock" }}
             - v1-dependency-cache
 
-      - run: mix local.hex --force  # install Hex locally (without prompt)
-      - run: mix local.rebar --force  # fetch a copy of rebar (without prompt)
+      - run: mix local.hex --force # install Hex locally (without prompt)
+      - run: mix local.rebar --force # fetch a copy of rebar (without prompt)
       - run:
           name: "Install Rust"
           command: |
@@ -36,6 +36,7 @@ jobs:
             mix format --check-formatted
             cargo fmt --manifest-path native/wasmex/Cargo.toml  -- --check
             mix dialyzer
+            mix credo
             mix docs
 
       - save_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Types of changes
 
-  * `Added` for new features.
-  * `Changed` for changes in existing functionality.
-  * `Deprecated` for soon-to-be removed features.
-  * `Removed` for now removed features.
-  * `Fixed` for any bug fixes.
-  * `Security` in case of vulnerabilities.
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Removed` for now removed features.
+- `Fixed` for any bug fixes.
+- `Security` in case of vulnerabilities.
 
-## [Unreleased]
+## [Unreleased - 0.2.0]
+
+This release brings is closer to a production-ready experience.
+Calls of WebAssembly functions are now handled asynchronously: Invoking a WASM function via `Instance.call_exported_function` calls our Rust NIF as before, but does not directly execute the function. Instead, a new OS thread is spawned for the actual execution. This allows us to spend only few time in the NIF code (as required by the Erlang VM). Once the WASM function in that thread returns, we send a message to the calling erlang process.
+To ease handling, we converted our main module `Wasmex` into a `GenServer` so that a WASM function call can be used in a synchronous manner as before.
 
 ### Added
 
-* Fixed: Enhanced documentation
-* Changed: Removed unused Rust dependencies
-* Provide better error messages for Wasmex.Instance.from_bytes when the WASM instance could not be instantiated.
+- Changed: The Wasmex module is now a GenServer. WASM function calls are now asynchronous
+- Removed: Instance.call_exported_function/2 use Instance.call_exported_function/3 instead.
+- Fixed: Enhanced documentation
+- Changed: Removed unused Rust dependencies
+- Provide better error messages for Wasmex.Instance.from_bytes when the WASM instance could not be instantiated.
 
 ## [0.1.0] - 2020-01-15
 
 ### Changed
 
-* First release
+- First release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,16 @@ To ease handling, we converted our main module `Wasmex` into a `GenServer` so th
 ### Added
 
 - Changed: The Wasmex module is now a GenServer. WASM function calls are now asynchronous
-- Removed: Instance.call_exported_function/2 use Instance.call_exported_function/3 instead.
-- Fixed: Enhanced documentation
-- Changed: Removed unused Rust dependencies
+- Removed unused Rust dependencies
 - Provide better error messages for Wasmex.Instance.from_bytes when the WASM instance could not be instantiated.
+
+### Removed
+
+- Instance.call_exported_function/2 use Instance.call_exported_function/3 instead.
+
+### Fixed
+
+- Enhanced documentation
 
 ## [0.1.0] - 2020-01-15
 

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -2,14 +2,13 @@ defmodule Wasmex do
   @moduledoc """
   Wasmex is an Elixir library for executing WebAssembly binaries.
 
-  WASM files can be executed using a WebAssembly `Wasmex.Instance`:
+  WASM functions can be executed like this:
 
   ```elixir
   {:ok, bytes } = File.read("wasmex_test.wasm")
-  {:ok, instance } = Wasmex.Instance.from_bytes(bytes)
+  {:ok, instance } = Wasmex.start_link.from_bytes(bytes)
 
-  instance
-    |> Wasmex.Instance.call_exported_function("sum", [50, -8])
+  {:ok, [42]} == Wasmex.call_function(instance, "sum", [50, -8])
   ```
 
   Memory can be read/written using `Wasmex.Memory`:
@@ -24,4 +23,56 @@ defmodule Wasmex do
   IO.puts Wasmex.Memory.get(memory, index) # 42
   ```
   """
+  use GenServer
+
+  # Client
+
+  def start_link(bytes) when is_binary(bytes) do
+    GenServer.start_link(__MODULE__, bytes)
+  end
+
+  def function_exists(pid, name) do
+    GenServer.call(pid, {:exported_function_exists, name})
+  end
+
+  def call_function(pid, name, params) do
+    GenServer.call(pid, {:call_function, name, params})
+  end
+
+  def memory(pid, size, offset) when size in [:uint8, :int8, :uint16, :int16, :uint32, :int32] do
+    GenServer.call(pid, {:memory, size, offset})
+  end
+
+  # Server
+
+  @impl true
+  def init(bytes) when is_binary(bytes) do
+    {:ok, instance} = Wasmex.Instance.from_bytes(bytes)
+    {:ok, %{instance: instance}}
+  end
+
+  @impl true
+  def handle_call({:memory, size, offset}, _from, %{instance: instance}) when size in [:uint8, :int8, :uint16, :int16, :uint32, :int32] do
+    case Wasmex.Memory.from_instance(instance, size, offset) do
+      {:ok, memory} -> {:reply, {:ok, memory}, %{instance: instance}}
+      {:error, error} -> {:reply, {:error, error}, %{instance: instance}}
+    end
+  end
+
+  @impl true
+  def handle_call({:exported_function_exists, name}, _from, %{instance: instance}) when is_binary(name) do
+    {:reply, Wasmex.Instance.function_export_exists(instance, name), %{instance: instance}}
+  end
+
+  @impl true
+  def handle_call({:call_function, name, params}, from, %{instance: instance}) do
+    :ok = Wasmex.Instance.call_exported_function(instance, name, params, from)
+    {:noreply, %{instance: instance}}
+  end
+
+  @impl true
+  def handle_info({:returned_function_call, result, from}, state) do
+    GenServer.reply(from, result)
+    {:noreply, state}
+  end
 end

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -52,7 +52,8 @@ defmodule Wasmex do
   end
 
   @impl true
-  def handle_call({:memory, size, offset}, _from, %{instance: instance}) when size in [:uint8, :int8, :uint16, :int16, :uint32, :int32] do
+  def handle_call({:memory, size, offset}, _from, %{instance: instance})
+      when size in [:uint8, :int8, :uint16, :int16, :uint32, :int32] do
     case Wasmex.Memory.from_instance(instance, size, offset) do
       {:ok, memory} -> {:reply, {:ok, memory}, %{instance: instance}}
       {:error, error} -> {:reply, {:error, error}, %{instance: instance}}
@@ -60,7 +61,8 @@ defmodule Wasmex do
   end
 
   @impl true
-  def handle_call({:exported_function_exists, name}, _from, %{instance: instance}) when is_binary(name) do
+  def handle_call({:exported_function_exists, name}, _from, %{instance: instance})
+      when is_binary(name) do
     {:reply, Wasmex.Instance.function_export_exists(instance, name), %{instance: instance}}
   end
 

--- a/lib/wasmex/instance.ex
+++ b/lib/wasmex/instance.ex
@@ -72,7 +72,7 @@ defmodule Wasmex.Instance do
   containing a list of the results form the called WebAssembly function.
 
   Calling `call_exported_function` usually returns an `:ok` atom but may throw a BadArg exception when given
-  unexpected input data.
+  unexpected input data. 
   """
   @spec call_exported_function(__MODULE__.t(), binary(), [any()], GenServer.from()) :: any()
   def call_exported_function(%__MODULE__{resource: resource}, name, params, from)

--- a/lib/wasmex/native.ex
+++ b/lib/wasmex/native.ex
@@ -8,7 +8,7 @@ defmodule Wasmex.Native do
 
   def instance_new_from_bytes(_bytes), do: error()
   def instance_function_export_exists(_resource, _function_name), do: error()
-  def instance_call_exported_function(_resource, _function_name, _params), do: error()
+  def instance_call_exported_function(_resource, _function_name, _params, _from), do: error()
   def memory_from_instance(_resource), do: error()
   def memory_bytes_per_element(_resource, _size, _offset), do: error()
   def memory_length(_resource, _size, _offset), do: error()

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,8 @@ defmodule Wasmex.MixProject do
     [
       {:rustler, "~> 0.21.0"},
       {:ex_doc, "~> 0.21.2", only: [:dev, :test]},
-      {:dialyxir, "~> 1.0.0-rc.7", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 1.0.0", only: [:dev, :test], runtime: false},
+      {:credo, "~> 1.3", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,11 @@
 %{
-  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "1.3.2", "08d456dcf3c24da162d02953fb07267e444469d8dad3a2ae47794938ea467b3a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
-  "erlex": {:hex, :erlex, "0.2.5", "e51132f2f472e13d606d808f0574508eeea2030d487fc002b46ad97e738b0510", [:mix], [], "hexpm"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.2.0", "10043418c42d2493d0ee212d3fddd25d7ffe484380afad769a0a38795938e448", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},

--- a/native/wasmex/src/atoms.rs
+++ b/native/wasmex/src/atoms.rs
@@ -9,4 +9,6 @@ rustler::rustler_atoms! {
     atom int16;
     atom uint32;
     atom int32;
+
+    atom returned_function_call;
 }

--- a/native/wasmex/src/instance.rs
+++ b/native/wasmex/src/instance.rs
@@ -1,9 +1,13 @@
 use rustler::dynamic::TermType;
+use rustler::env::{OwnedEnv, SavedTerm};
 use rustler::resource::ResourceArc;
 use rustler::types::binary::Binary;
+use rustler::types::tuple::make_tuple;
 use rustler::{Encoder, Env, Error, Term};
 use std::sync::Mutex;
+use std::thread;
 use wasmer_runtime::{self as runtime, imports};
+use wasmer_runtime_core::instance::DynFunc;
 use wasmer_runtime_core::types::Type;
 
 use crate::printable_term_type::PrintableTermType;
@@ -38,96 +42,204 @@ pub fn function_export_exists<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Ter
 }
 
 pub fn call_exported_function<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
+    let pid = env.pid();
+    // create erlang environment for the thread
+    let mut thread_env = OwnedEnv::new();
+    // copy over params into the thread environment
     let resource: ResourceArc<InstanceResource> = args[0].decode()?;
-    let given_name: String = args[1].decode()?;
-    let given_params: Vec<Term> = args[2].decode()?;
-    let instance = resource.instance.lock().unwrap();
+    let function_name: String = args[1].decode()?;
+    let function_params = thread_env.save(args[2]);
+    let from = thread_env.save(args[3]);
+    args[3].decode::<Term>()?; // make sure the `from` param exists, as we cannot safely return errors without it in execute_function
+    thread::spawn(move || {
+        thread_env.send_and_clear(&pid, |thread_env| {
+            execute_function(thread_env, resource, function_name, function_params, from)
+        })
+    });
 
-    let function = match functions::find(&instance, &given_name) {
-        Ok(f) => f,
+    Ok(atoms::ok().encode(env))
+}
+
+fn execute_function<'a>(
+    thread_env: Env<'a>,
+    resource: ResourceArc<InstanceResource>,
+    function_name: String,
+    function_params: SavedTerm,
+    from: SavedTerm,
+) -> Term<'a> {
+    let returned_function_call_atom = atoms::returned_function_call().encode(thread_env);
+    let from = from
+        .load(thread_env)
+        .decode::<Term>()
+        .unwrap_or("could not load 'from' param".encode(thread_env));
+    let given_params = match function_params.load(thread_env).decode::<Vec<Term>>() {
+        Ok(vec) => vec,
         Err(_) => {
-            return Err(Error::RaiseTerm(Box::new(format!(
-                "exported function `{}` not found",
-                given_name
-            ))))
+            return make_tuple(
+                thread_env,
+                &[
+                    returned_function_call_atom,
+                    thread_env.error_tuple("could not load 'function params'"),
+                    from,
+                ],
+            )
         }
     };
+    let instance = resource.instance.lock().unwrap();
+    let function = match functions::find(&instance, &function_name) {
+        Ok(f) => f,
+        Err(_) => {
+            return make_tuple(
+                thread_env,
+                &[
+                    returned_function_call_atom,
+                    thread_env
+                        .error_tuple(format!("exported function `{}` not found", function_name)),
+                    from,
+                ],
+            )
+        }
+    };
+    let function_params = match decode_function_param_terms(&function, given_params) {
+        Ok(vec) => vec,
+        Err(reason) => {
+            return make_tuple(
+                thread_env,
+                &[
+                    returned_function_call_atom,
+                    thread_env.error_tuple(reason),
+                    from,
+                ],
+            )
+        }
+    };
+
+    let results = match function.call(function_params.as_slice()) {
+        Ok(results) => results,
+        Err(e) => {
+            return make_tuple(
+                thread_env,
+                &[
+                    returned_function_call_atom,
+                    thread_env.error_tuple(format!("Runtime Error `{}`.", e).encode(thread_env)),
+                    from,
+                ],
+            )
+        }
+    };
+    let mut return_values: Vec<Term> = Vec::with_capacity(results.len());
+    for value in results {
+        return_values.push(match value {
+            runtime::Value::I32(i) => i.encode(thread_env),
+            runtime::Value::I64(i) => i.encode(thread_env),
+            runtime::Value::F32(i) => i.encode(thread_env),
+            runtime::Value::F64(i) => i.encode(thread_env),
+            // encoding V128 is not yet supported by rustler
+            runtime::Value::V128(_) => {
+                return make_tuple(
+                    thread_env,
+                    &[
+                        returned_function_call_atom,
+                        thread_env.error_tuple("unable_to_return_v128_type"),
+                        from,
+                    ],
+                )
+            }
+        })
+    }
+    make_tuple(
+        thread_env,
+        &[
+            returned_function_call_atom,
+            make_tuple(
+                thread_env,
+                &[
+                    atoms::ok().encode(thread_env),
+                    return_values.encode(thread_env),
+                ],
+            ),
+            from,
+        ],
+    )
+}
+
+fn decode_function_param_terms(
+    function: &DynFunc,
+    function_param_terms: Vec<Term>,
+) -> Result<Vec<runtime::Value>, String> {
     let signature = function.signature();
     let params = signature.params();
-    if 0 != params.len() as isize - given_params.len() as isize {
-        return Err(Error::RaiseTerm(Box::new(format!(
+    if 0 != params.len() as isize - function_param_terms.len() as isize {
+        return Err(format!(
             "number of params does not match. expected {}, got {}",
             params.len(),
-            given_params.len()
-        ))));
+            function_param_terms.len()
+        ));
     }
 
     let mut function_params = Vec::<runtime::Value>::with_capacity(params.len() as usize);
-    for (nth, (param, given_param)) in params.iter().zip(given_params.into_iter()).enumerate() {
+    for (nth, (param, given_param)) in params
+        .iter()
+        .zip(function_param_terms.into_iter())
+        .enumerate()
+    {
         let value = match (param, given_param.get_type()) {
             (Type::I32, TermType::Number) => runtime::Value::I32(match given_param.decode() {
                 Ok(value) => value,
                 Err(_) => {
-                    return Err(Error::RaiseTerm(Box::new(format!(
+                    return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly i32 value.",
                         nth + 1
-                    ))))
+                    ))
                 }
             }),
             (Type::I64, TermType::Number) => runtime::Value::I64(match given_param.decode() {
                 Ok(value) => value,
                 Err(_) => {
-                    return Err(Error::RaiseTerm(Box::new(format!(
+                    return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly i64 value.",
                         nth + 1
-                    ))))
+                    ))
                 }
             }),
-            (Type::F32, TermType::Number) => runtime::Value::F32(match given_param.decode() {
-                Ok(value) => value,
-                Err(_) => {
-                    return Err(Error::RaiseTerm(Box::new(format!(
-                        "Cannot convert argument #{} to a WebAssembly f32 value.",
-                        nth + 1
-                    ))))
-                }
-            }),
+            (Type::F32, TermType::Number) => {
+                runtime::Value::F32(match given_param.decode::<f32>() {
+                    Ok(value) => {
+                        if value.is_finite() {
+                            value
+                        } else {
+                            return Err(format!(
+                                "Cannot convert argument #{} to a WebAssembly f32 value.",
+                                nth + 1
+                            ));
+                        }
+                    }
+                    Err(_) => {
+                        return Err(format!(
+                            "Cannot convert argument #{} to a WebAssembly f32 value.",
+                            nth + 1
+                        ))
+                    }
+                })
+            }
             (Type::F64, TermType::Number) => runtime::Value::F64(match given_param.decode() {
                 Ok(value) => value,
                 Err(_) => {
-                    return Err(Error::RaiseTerm(Box::new(format!(
+                    return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly f64 value.",
                         nth + 1
-                    ))))
+                    ))
                 }
             }),
             (_, term_type) => {
-                return Err(Error::RaiseTerm(Box::new(format!(
+                return Err(format!(
                     "Cannot convert argument #{} to a WebAssembly value. Given `{:?}`.",
                     nth + 1,
                     PrintableTermType::PrintTerm(term_type)
-                ))))
+                ))
             }
         };
         function_params.push(value);
     }
-
-    let results = match function.call(function_params.as_slice()) {
-        Ok(results) => results,
-        Err(e) => return Ok((atoms::error(), &format!("Runtime Error `{}`.", e)).encode(env)),
-    };
-
-    if results.is_empty() {
-        Ok(atoms::__nil__().encode(env))
-    } else {
-        let return_value = match results[0] {
-            runtime::Value::I32(result) => result.encode(env),
-            runtime::Value::I64(result) => result.encode(env),
-            runtime::Value::F32(result) => result.encode(env),
-            runtime::Value::F64(result) => result.encode(env),
-            // encoding V128 is not yet supported by rustler
-            runtime::Value::V128(_result) => return Err(Error::Atom("unable_to_return_v128_type")),
-        };
-        Ok(return_value)
-    }
+    Ok(function_params)
 }

--- a/native/wasmex/src/lib.rs
+++ b/native/wasmex/src/lib.rs
@@ -15,7 +15,7 @@ rustler::rustler_export_nifs! {
     [
         ("instance_new_from_bytes", 1, instance::new_from_bytes),
         ("instance_function_export_exists", 2, instance::function_export_exists),
-        ("instance_call_exported_function", 3, instance::call_exported_function),
+        ("instance_call_exported_function", 4, instance::call_exported_function),
         ("memory_from_instance", 1, memory::from_instance),
         ("memory_bytes_per_element", 3, memory::bytes_per_element),
         ("memory_length", 3, memory::length),

--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -128,13 +128,14 @@ fn get_value<'a>(
     index: usize,
     element_size: ElementSize,
 ) -> Term<'a> {
+    let i = offset + index;
     match element_size {
-        ElementSize::Uint8 => memory.view::<u8>()[offset + index].get().encode(*env),
-        ElementSize::Int8 => memory.view::<i8>()[offset + index].get().encode(*env),
-        ElementSize::Uint16 => memory.view::<u16>()[offset + index].get().encode(*env),
-        ElementSize::Int16 => memory.view::<i16>()[offset + index].get().encode(*env),
-        ElementSize::Uint32 => memory.view::<u32>()[offset + index].get().encode(*env),
-        ElementSize::Int32 => memory.view::<i32>()[offset + index].get().encode(*env),
+        ElementSize::Uint8 => memory.view::<u8>()[i].get().encode(*env),
+        ElementSize::Int8 => memory.view::<i8>()[i].get().encode(*env),
+        ElementSize::Uint16 => memory.view::<u16>()[i].get().encode(*env),
+        ElementSize::Int16 => memory.view::<i16>()[i].get().encode(*env),
+        ElementSize::Uint32 => memory.view::<u32>()[i].get().encode(*env),
+        ElementSize::Int32 => memory.view::<i32>()[i].get().encode(*env),
     }
 }
 

--- a/test/wasm_source/src/lib.rs
+++ b/test/wasm_source/src/lib.rs
@@ -48,8 +48,13 @@ pub extern "C" fn void() {}
 
 #[no_mangle]
 pub extern "C" fn string_first_byte(s: &str) -> u8 {
-  match s.bytes().nth(0) {
-    Some(i) => i,
-    None => 0
-  }
+    match s.bytes().nth(0) {
+        Some(i) => i,
+        None => 0,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn endless_loop() -> () {
+    loop {}
 }

--- a/test/wasmex/instance_test.exs
+++ b/test/wasmex/instance_test.exs
@@ -31,139 +31,41 @@ defmodule Wasmex.InstanceTest do
     end
   end
 
-  describe "call_exported_function/2" do
-    test "runs functions which returns an integer" do
-      {:ok, instance} = build_wasm_instance()
-      assert 42 == Wasmex.Instance.call_exported_function(instance, "arity_0")
-    end
-  end
-
   describe "call_exported_function/3" do
-    test "runs functions without params" do
+    test "calling a function sends an async message back to self" do
       {:ok, instance} = build_wasm_instance()
-      assert 42 == Wasmex.Instance.call_exported_function(instance, "arity_0", [])
-    end
+      assert :ok == Wasmex.Instance.call_exported_function(instance, "arity_0", [], :fake_from)
 
-    test "calling the sum(i32, i32) function" do
-      {:ok, instance} = build_wasm_instance()
-      assert 42 == Wasmex.Instance.call_exported_function(instance, "sum", [50, -8])
-    end
-
-    test "calling the sum(i32, i32) function with wrong number of params" do
-      {:ok, instance} = build_wasm_instance()
-
-      assert_raise ErlangError,
-                   "Erlang error: \"number of params does not match. expected 2, got 1\"",
-                   fn ->
-                     Wasmex.Instance.call_exported_function(instance, "sum", [3])
-                   end
-
-      assert_raise ErlangError,
-                   "Erlang error: \"number of params does not match. expected 2, got 3\"",
-                   fn ->
-                     Wasmex.Instance.call_exported_function(instance, "sum", [3, 4, 5])
-                   end
-    end
-
-    test "calling a function that does not exist" do
-      {:ok, instance} = build_wasm_instance()
-
-      assert_raise ErlangError, "Erlang error: \"exported function `sum42` not found\"", fn ->
-        Wasmex.Instance.call_exported_function(instance, "sum42", [])
+      receive do
+        {:returned_function_call, {:ok, [42]}, :fake_from} -> nil
+      after
+        1000 ->
+          raise "message_expected"
       end
     end
 
-    test "using i32 as param and return value" do
+    test "calling a function with error sends an error message back to self" do
       {:ok, instance} = build_wasm_instance()
-      assert -3 == Wasmex.Instance.call_exported_function(instance, "i32_i32", [-3])
+      assert :ok == Wasmex.Instance.call_exported_function(instance, "arity_0", [1], :fake_from)
 
-      # a value greater than i32::max_value()
-      # see: https://doc.rust-lang.org/std/primitive.i32.html#method.max_value
-      assert_raise ErlangError,
-                   "Erlang error: \"Cannot convert argument #1 to a WebAssembly i32 value.\"",
-                   fn ->
-                     Wasmex.Instance.call_exported_function(instance, "i32_i32", [3_000_000_000])
-                   end
-    end
-
-    test "using i64 as param and return value" do
-      {:ok, instance} = build_wasm_instance()
-      assert -3 == Wasmex.Instance.call_exported_function(instance, "i64_i64", [-3])
-
-      # a value greater than i32::max_value()
-      # see: https://doc.rust-lang.org/std/primitive.i32.html#method.max_value
-      assert 3_000_000_000 ==
-               Wasmex.Instance.call_exported_function(instance, "i64_i64", [3_000_000_000])
-    end
-
-    test "using f32 as param and return value" do
-      {:ok, instance} = build_wasm_instance()
-
-      assert_in_delta 3.14,
-                      Wasmex.Instance.call_exported_function(instance, "f32_f32", [3.14]),
-                      0.001
-
-      # a value greater than f32::max_value()
-      assert_raise ArgumentError, fn ->
-        Wasmex.Instance.call_exported_function(instance, "f32_f32", [3.4e42])
+      receive do
+        {:returned_function_call, {:error, "number of params does not match. expected 0, got 1"}, :fake_from} -> nil
+      after
+        1000 ->
+          raise "message_expected"
       end
     end
 
-    test "using f64 as param and return value" do
+    test "calling a function that never returns" do
       {:ok, instance} = build_wasm_instance()
+      assert :ok == Wasmex.Instance.call_exported_function(instance, "endless_loop", [], :fake_from)
 
-      assert_in_delta 3.14,
-                      Wasmex.Instance.call_exported_function(instance, "f64_f64", [3.14]),
-                      0.001
-
-      # a value greater than f32::max_value()
-      assert 3.4e42 == Wasmex.Instance.call_exported_function(instance, "f64_f64", [3.4e42])
-    end
-
-    test "using different param types as params" do
-      {:ok, instance} = build_wasm_instance()
-
-      assert_in_delta 20.4,
-                      Wasmex.Instance.call_exported_function(instance, "i32_i64_f32_f64_f64", [
-                        3,
-                        4,
-                        5.6,
-                        7.8
-                      ]),
-                      0.001
-    end
-
-    test "calling a function with a boolean return value" do
-      {:ok, instance} = build_wasm_instance()
-      assert 1 == Wasmex.Instance.call_exported_function(instance, "bool_casted_to_i32", [])
-    end
-
-    test "calling a function with no return value" do
-      {:ok, instance} = build_wasm_instance()
-      assert nil == Wasmex.Instance.call_exported_function(instance, "void", [])
-    end
-
-    test "calling a function which returns a string pointer" do
-      {:ok, instance} = build_wasm_instance()
-      pointer = Wasmex.Instance.call_exported_function(instance, "string", [])
-      {:ok, memory} = Wasmex.Instance.memory(instance, :uint8, 0)
-      returned_string = Wasmex.Memory.read_binary(memory, pointer)
-      assert returned_string == "Hello, World!"
-    end
-
-    test "calling a function which gets a string as param" do
-      {:ok, instance} = build_wasm_instance()
-      {:ok, memory} = Wasmex.Instance.memory(instance, :uint8, 0)
-      string = "hello, world"
-      index = 42
-
-      Wasmex.Memory.write_binary(memory, index, string)
-
-      assert 104 ==
-               Wasmex.Instance.call_exported_function(instance, "string_first_byte", [
-                 index,
-                 String.length(string)
-               ])
+      receive do
+        _ -> raise "no receive expected"
+      after
+        100 ->
+          nil
+      end
     end
   end
 

--- a/test/wasmex/instance_test.exs
+++ b/test/wasmex/instance_test.exs
@@ -49,7 +49,9 @@ defmodule Wasmex.InstanceTest do
       assert :ok == Wasmex.Instance.call_exported_function(instance, "arity_0", [1], :fake_from)
 
       receive do
-        {:returned_function_call, {:error, "number of params does not match. expected 0, got 1"}, :fake_from} -> nil
+        {:returned_function_call, {:error, "number of params does not match. expected 0, got 1"},
+         :fake_from} ->
+          nil
       after
         1000 ->
           raise "message_expected"
@@ -58,7 +60,9 @@ defmodule Wasmex.InstanceTest do
 
     test "calling a function that never returns" do
       {:ok, instance} = build_wasm_instance()
-      assert :ok == Wasmex.Instance.call_exported_function(instance, "endless_loop", [], :fake_from)
+
+      assert :ok ==
+               Wasmex.Instance.call_exported_function(instance, "endless_loop", [], :fake_from)
 
       receive do
         _ -> raise "no receive expected"

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -15,11 +15,13 @@ defmodule WasmexTest do
   end
 
   test "call_function: calling an unknown function", %{instance: instance} do
-    assert {:error, "exported function `unknown_function` not found"} = Wasmex.call_function(instance, "unknown_function", [1])
+    assert {:error, "exported function `unknown_function` not found"} =
+             Wasmex.call_function(instance, "unknown_function", [1])
   end
 
   test "call_function: arity0 with too many params", %{instance: instance} do
-    assert {:error, "number of params does not match. expected 0, got 1"} = Wasmex.call_function(instance, "arity_0", [1])
+    assert {:error, "number of params does not match. expected 0, got 1"} =
+             Wasmex.call_function(instance, "arity_0", [1])
   end
 
   test "call_function: arity0 -> i32", %{instance: instance} do
@@ -35,7 +37,8 @@ defmodule WasmexTest do
 
     # giving a value greater than i32::max_value()
     # see: https://doc.rust-lang.org/std/primitive.i32.html#method.max_value
-    assert {:error, "Cannot convert argument #1 to a WebAssembly i32 value."} == Wasmex.call_function(instance, "i32_i32", [3_000_000_000])
+    assert {:error, "Cannot convert argument #1 to a WebAssembly i32 value."} ==
+             Wasmex.call_function(instance, "i32_i32", [3_000_000_000])
   end
 
   test "call_function: i64_i64(i64) -> i64 function", %{instance: instance} do
@@ -48,16 +51,19 @@ defmodule WasmexTest do
 
   test "call_function: f32_f32(f32) -> f32 function", %{instance: instance} do
     {:ok, [result]} = Wasmex.call_function(instance, "f32_f32", [3.14])
+
     assert_in_delta 3.14,
                     result,
                     0.001
 
     # a value greater than f32::max_value()
-    assert {:error, "Cannot convert argument #1 to a WebAssembly f32 value."} == Wasmex.call_function(instance, "f32_f32", [3.5e38])
+    assert {:error, "Cannot convert argument #1 to a WebAssembly f32 value."} ==
+             Wasmex.call_function(instance, "f32_f32", [3.5e38])
   end
 
   test "call_function: f64_f64(f64) -> f64 function", %{instance: instance} do
     {:ok, [result]} = Wasmex.call_function(instance, "f64_f64", [3.14])
+
     assert_in_delta 3.14,
                     result,
                     0.001
@@ -66,8 +72,11 @@ defmodule WasmexTest do
     assert {:ok, [3.5e38]} == Wasmex.call_function(instance, "f64_f64", [3.5e38])
   end
 
-  test "call_function: i32_i64_f32_f64_f64(i32, i64, f32, f64) -> f64 function", %{instance: instance} do
+  test "call_function: i32_i64_f32_f64_f64(i32, i64, f32, f64) -> f64 function", %{
+    instance: instance
+  } do
     {:ok, [result]} = Wasmex.call_function(instance, "i32_i64_f32_f64_f64", [3, 4, 5.6, 7.8])
+
     assert_in_delta 20.4,
                     result,
                     0.001
@@ -94,6 +103,7 @@ defmodule WasmexTest do
     index = 42
     Wasmex.Memory.write_binary(memory, index, string)
 
-    assert {:ok, [104]} == Wasmex.call_function(instance, "string_first_byte", [index, String.length(string)])
+    assert {:ok, [104]} ==
+             Wasmex.call_function(instance, "string_first_byte", [index, String.length(string)])
   end
 end

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -1,4 +1,99 @@
 defmodule WasmexTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Wasmex
+
+  @bytes File.read!(TestHelper.wasm_file_path())
+
+  setup do
+    instance = start_supervised!({Wasmex, @bytes})
+    %{instance: instance}
+  end
+
+  test "function_exists", %{instance: instance} do
+    assert Wasmex.function_exists(instance, "arity_0")
+    assert !Wasmex.function_exists(instance, "unknown_function")
+  end
+
+  test "call_function: calling an unknown function", %{instance: instance} do
+    assert {:error, "exported function `unknown_function` not found"} = Wasmex.call_function(instance, "unknown_function", [1])
+  end
+
+  test "call_function: arity0 with too many params", %{instance: instance} do
+    assert {:error, "number of params does not match. expected 0, got 1"} = Wasmex.call_function(instance, "arity_0", [1])
+  end
+
+  test "call_function: arity0 -> i32", %{instance: instance} do
+    assert {:ok, [42]} = Wasmex.call_function(instance, "arity_0", [])
+  end
+
+  test "call_function: sum(i32, i32) -> i32 function", %{instance: instance} do
+    assert {:ok, [42]} == Wasmex.call_function(instance, "sum", [50, -8])
+  end
+
+  test "call_function: i32_i32(i32) -> i32 function", %{instance: instance} do
+    assert {:ok, [-3]} == Wasmex.call_function(instance, "i32_i32", [-3])
+
+    # giving a value greater than i32::max_value()
+    # see: https://doc.rust-lang.org/std/primitive.i32.html#method.max_value
+    assert {:error, "Cannot convert argument #1 to a WebAssembly i32 value."} == Wasmex.call_function(instance, "i32_i32", [3_000_000_000])
+  end
+
+  test "call_function: i64_i64(i64) -> i64 function", %{instance: instance} do
+    assert {:ok, [-3]} == Wasmex.call_function(instance, "i64_i64", [-3])
+
+    # giving a value greater than i32::max_value()
+    # see: https://doc.rust-lang.org/std/primitive.i32.html#method.max_value
+    assert {:ok, [3_000_000_000]} == Wasmex.call_function(instance, "i64_i64", [3_000_000_000])
+  end
+
+  test "call_function: f32_f32(f32) -> f32 function", %{instance: instance} do
+    {:ok, [result]} = Wasmex.call_function(instance, "f32_f32", [3.14])
+    assert_in_delta 3.14,
+                    result,
+                    0.001
+
+    # a value greater than f32::max_value()
+    assert {:error, "Cannot convert argument #1 to a WebAssembly f32 value."} == Wasmex.call_function(instance, "f32_f32", [3.5e38])
+  end
+
+  test "call_function: f64_f64(f64) -> f64 function", %{instance: instance} do
+    {:ok, [result]} = Wasmex.call_function(instance, "f64_f64", [3.14])
+    assert_in_delta 3.14,
+                    result,
+                    0.001
+
+    # a value greater than f32::max_value()
+    assert {:ok, [3.5e38]} == Wasmex.call_function(instance, "f64_f64", [3.5e38])
+  end
+
+  test "call_function: i32_i64_f32_f64_f64(i32, i64, f32, f64) -> f64 function", %{instance: instance} do
+    {:ok, [result]} = Wasmex.call_function(instance, "i32_i64_f32_f64_f64", [3, 4, 5.6, 7.8])
+    assert_in_delta 20.4,
+                    result,
+                    0.001
+  end
+
+  test "call_function: bool_casted_to_i32() -> i32 function", %{instance: instance} do
+    assert {:ok, [1]} == Wasmex.call_function(instance, "bool_casted_to_i32", [])
+  end
+
+  test "call_function: void() -> () function", %{instance: instance} do
+    assert {:ok, []} == Wasmex.call_function(instance, "void", [])
+  end
+
+  test "call_function: string() -> string function", %{instance: instance} do
+    {:ok, [pointer]} = Wasmex.call_function(instance, "string", [])
+    {:ok, memory} = Wasmex.memory(instance, :uint8, 0)
+    returned_string = Wasmex.Memory.read_binary(memory, pointer)
+    assert returned_string == "Hello, World!"
+  end
+
+  test "call_function: string_first_byte(string_pointer) -> u8 function", %{instance: instance} do
+    {:ok, memory} = Wasmex.memory(instance, :uint8, 0)
+    string = "hello, world"
+    index = 42
+    Wasmex.Memory.write_binary(memory, index, string)
+
+    assert {:ok, [104]} == Wasmex.call_function(instance, "string_first_byte", [index, String.length(string)])
+  end
 end


### PR DESCRIPTION
This release brings is closer to a production-ready experience. 🎉 

Calls of WebAssembly functions are now handled asynchronously: Invoking a WASM function via `Instance.call_exported_function` calls our Rust NIF as before, but does not directly execute the function. Instead, a new OS thread is spawned for the actual execution. This allows us to spend only few time in the NIF code (as required by the Erlang VM). Once the WASM function in that thread returns, we send a message to the calling erlang process.
To ease handling, we converted our main module `Wasmex` into a `GenServer` so that a WASM function call can be used in a synchronous manner as before.

fixes #6 