### PR TITLE
Adding wasmer as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "wasmer"]
+	path = wasmer
+	url = https://github.com/wasmerio/wasmer.git

--- a/native/wasmex/Cargo.toml
+++ b/native/wasmex/Cargo.toml
@@ -17,5 +17,5 @@ crate-type = ["dylib"]
 [dependencies]
 rustler = "0.21.0"
 lazy_static = "1.0"
-wasmer-runtime = {path = "../../../wasmer/lib/runtime", version = "0.16.2"}
-wasmer-runtime-core = {path = "../../../wasmer/lib/runtime-core", version = "0.16.2", features = ["dynamicfunc-fat-closures"]}
+wasmer-runtime = {path = "../../wasmer/lib/runtime", version = "0.16.2"}
+wasmer-runtime-core = {path = "../../wasmer/lib/runtime-core", version = "0.16.2", features = ["dynamicfunc-fat-closures"]}


### PR DESCRIPTION
...to be able to compile against master more easily. This made it possible for me to use the branch as a hex dependency directly like: `{:wasmex, github: "myobie/wasmex", branch: "prototype_imports", submodules: true}`

_(I understand the dependency on wasmer master will go away in the future, so maybe this isn't worth merging if that is soon.)_