### PR TITLE
Decode import params and results into types

### DIFF
--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -94,7 +94,6 @@ defmodule Wasmex do
 
   @impl true
   def handle_info({:invoke_callback, namespace_name, import_name, params, token}, %{imports: imports} = state) do
-    # token = Wasmex.CallbackToken.wrap_resource(token)
     {success, return_value} = try do
       {_params, _returns, callback} = imports
                                       |> Map.get(namespace_name, %{})
@@ -104,7 +103,7 @@ defmodule Wasmex do
       e in RuntimeError -> {false, e.message}
     end
 
-    Wasmex.Native.namespace_receive_callback_result(token, success, [return_value])
+    :ok = Wasmex.Native.namespace_receive_callback_result(token, success, [return_value])
     {:noreply, state}
   end
 end

--- a/native/wasmex/src/atoms.rs
+++ b/native/wasmex/src/atoms.rs
@@ -11,6 +11,12 @@ rustler::rustler_atoms! {
     atom uint32;
     atom int32;
 
+    atom i32;
+    atom i64;
+    atom f32;
+    atom f64;
+    atom v128;
+
     atom params;
     atom results;
 

--- a/native/wasmex/src/instance.rs
+++ b/native/wasmex/src/instance.rs
@@ -162,7 +162,7 @@ pub fn decode_function_param_terms(
                     return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly i32 value.",
                         nth + 1
-                    ))
+                    ));
                 }
             }),
             (Type::I64, TermType::Number) => runtime::Value::I64(match given_param.decode() {
@@ -171,7 +171,7 @@ pub fn decode_function_param_terms(
                     return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly i64 value.",
                         nth + 1
-                    ))
+                    ));
                 }
             }),
             (Type::F32, TermType::Number) => {
@@ -190,7 +190,7 @@ pub fn decode_function_param_terms(
                         return Err(format!(
                             "Cannot convert argument #{} to a WebAssembly f32 value.",
                             nth + 1
-                        ))
+                        ));
                     }
                 })
             }
@@ -200,7 +200,7 @@ pub fn decode_function_param_terms(
                     return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly f64 value.",
                         nth + 1
-                    ))
+                    ));
                 }
             }),
             (_, term_type) => {
@@ -208,7 +208,7 @@ pub fn decode_function_param_terms(
                     "Cannot convert argument #{} to a WebAssembly value. Given `{:?}`.",
                     nth + 1,
                     PrintableTermType::PrintTerm(term_type)
-                ))
+                ));
             }
         };
         function_params.push(value);

--- a/native/wasmex/src/namespace.rs
+++ b/native/wasmex/src/namespace.rs
@@ -1,7 +1,8 @@
 //! Namespace API of an WebAssembly instance.
 
 use rustler::{
-    resource::ResourceArc, types::ListIterator, types::tuple, Atom, Encoder, Env, Error, MapIterator, OwnedEnv, Term,
+    resource::ResourceArc, types::tuple, types::ListIterator, Atom, Encoder, Env, Error,
+    MapIterator, OwnedEnv, Term,
 };
 use std::sync::{Arc, Condvar, Mutex};
 use wasmer_runtime::{self as runtime};
@@ -15,7 +16,6 @@ pub struct CallbackTokenResource {
     pub token: (
         Mutex<Option<(bool, Vec<runtime::Value>)>>,
         Condvar,
-        Vec<Type>,
         Vec<Type>,
     ),
 }
@@ -36,9 +36,7 @@ pub fn create_from_definition(
     Ok(namespace)
 }
 
-fn term_to_arg_type(
-    term: Term
-) -> Result<Type, Error> {
+fn term_to_arg_type(term: Term) -> Result<Type, Error> {
     match Atom::from_term(term) {
         Ok(atom) => {
             if atoms::i32().eq(&atom) {
@@ -55,9 +53,7 @@ fn term_to_arg_type(
                 Err(Error::Atom("unknown"))
             }
         }
-        Err(_) => {
-            Err(Error::Atom("not_an_atom"))
-        }
+        Err(_) => Err(Error::Atom("not_an_atom")),
     }
 }
 
@@ -70,8 +66,12 @@ fn create_imported_function(
 
     let import_tuple = tuple::get_tuple(definition)?;
 
-    let param_term = import_tuple.get(0).ok_or_else(|| Error::Atom("missing_params"))?;
-    let results_term = import_tuple.get(1).ok_or_else(|| Error::Atom("missing_results"))?;
+    let param_term = import_tuple
+        .get(0)
+        .ok_or_else(|| Error::Atom("missing_params"))?;
+    let results_term = import_tuple
+        .get(1)
+        .ok_or_else(|| Error::Atom("missing_results"))?;
 
     let params_signature = param_term
         .decode::<ListIterator>()?
@@ -83,18 +83,16 @@ fn create_imported_function(
         .map(|term| term_to_arg_type(term))
         .collect::<Result<Vec<Type>, _>>()?;
 
-    let signature = Arc::new(FuncSig::new(params_signature.clone(), results_signature.clone()));
+    let signature = Arc::new(FuncSig::new(
+        params_signature.clone(),
+        results_signature.clone(),
+    ));
 
     Ok(DynamicFunc::new(
         signature,
         move |_ctx: &mut Ctx, params: &[Value]| -> Vec<runtime::Value> {
             let callback_token = ResourceArc::new(CallbackTokenResource {
-                token: (
-                           Mutex::new(None),
-                           Condvar::new(),
-                           params_signature.clone(),
-                           results_signature.clone(),
-                       ),
+                token: (Mutex::new(None), Condvar::new(), results_signature.clone()),
             });
 
             let mut msg_env = OwnedEnv::new();
@@ -148,13 +146,12 @@ pub fn receive_callback_result<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Te
     let success = atoms::success() == args[1];
     let results = args[2].decode::<ListIterator>()?;
 
-    //TODO: use real signature
-    let signature = std::sync::Arc::new(FuncSig::new(vec![Type::I32], vec![Type::I32]));
-    let results = match decode_function_param_terms(signature.returns(), results.collect()) {
+    let return_types = token_resource.token.2.clone();
+    let results = match decode_function_param_terms(&return_types, results.collect()) {
         Ok(v) => v,
         Err(_reason) => {
             return Err(Error::Atom(
-                "could not convert callback result param to expected return signature (`{}`)",
+                "could not convert callback result param to expected return signature",
             ));
         }
     };

--- a/native/wasmex/src/namespace.rs
+++ b/native/wasmex/src/namespace.rs
@@ -15,8 +15,8 @@ pub struct CallbackTokenResource {
     pub token: (
         Mutex<Option<(bool, Vec<runtime::Value>)>>,
         Condvar,
-        Vec<String>,
-        Vec<String>,
+        Vec<Type>,
+        Vec<Type>,
     ),
 }
 
@@ -83,17 +83,7 @@ fn create_imported_function(
         .map(|term| term_to_arg_type(term))
         .collect::<Result<Vec<Type>, _>>()?;
 
-    let params_definition = param_term
-        .decode::<ListIterator>()?
-        .map(|term| term.atom_to_string())
-        .collect::<Result<Vec<String>, _>>()?;
-
-    let results_definition = results_term
-        .decode::<ListIterator>()?
-        .map(|term| term.atom_to_string())
-        .collect::<Result<Vec<String>, _>>()?;
-
-    let signature = Arc::new(FuncSig::new(params_signature, results_signature));
+    let signature = Arc::new(FuncSig::new(params_signature.clone(), results_signature.clone()));
 
     Ok(DynamicFunc::new(
         signature,
@@ -102,8 +92,8 @@ fn create_imported_function(
                 token: (
                            Mutex::new(None),
                            Condvar::new(),
-                           params_definition.clone(),
-                           results_definition.clone(),
+                           params_signature.clone(),
+                           results_signature.clone(),
                        ),
             });
 

--- a/native/wasmex/src/namespace.rs
+++ b/native/wasmex/src/namespace.rs
@@ -61,14 +61,6 @@ fn term_to_arg_type(
     }
 }
 
-fn get_from_vec<T: Copy>(vec: &Vec<T>, index: usize) -> Result<T, Error> {
-    if vec.get(index).is_none() {
-        Err(Error::Atom("missing_tuple_entry"))
-    } else {
-        Ok(vec[index])
-    }
-}
-
 fn create_imported_function(
     namespace_name: String,
     import_name: String,
@@ -77,8 +69,9 @@ fn create_imported_function(
     let pid = definition.get_env().pid();
 
     let import_tuple = tuple::get_tuple(definition)?;
-    let param_term = get_from_vec(&import_tuple, 0)?;
-    let results_term = get_from_vec(&import_tuple, 1)?;
+
+    let param_term = import_tuple.get(0).ok_or_else(|| Error::Atom("missing_params"))?;
+    let results_term = import_tuple.get(1).ok_or_else(|| Error::Atom("missing_results"))?;
 
     let params_signature = param_term
         .decode::<ListIterator>()?

--- a/test/wasm_import_test/src/lib.rs
+++ b/test/wasm_import_test/src/lib.rs
@@ -1,8 +1,14 @@
 extern "C" {
     fn imported_sum3(a: u32, b: u32, c: u32) -> u32;
+    fn imported_sumf(a: f32, b: f32) -> f32;
 }
 
 #[no_mangle]
 pub extern "C" fn using_imported_sum3(a: u32, b: u32, c: u32) -> u32 {
     unsafe { imported_sum3(a, b, c) }
+}
+
+#[no_mangle]
+pub extern "C" fn using_imported_sumf(a: f32, b: f32) -> f32 {
+    unsafe { imported_sumf(a, b) }
 }

--- a/test/wasm_import_test/src/lib.rs
+++ b/test/wasm_import_test/src/lib.rs
@@ -1,8 +1,8 @@
 extern "C" {
-    fn imported_sum(a: u32, b: u32) -> u32;
+    fn imported_sum3(a: u32, b: u32, c: u32) -> u32;
 }
 
 #[no_mangle]
-pub extern "C" fn using_imported_sum(a: u32, b: u32) -> u32 {
-    unsafe { imported_sum(a, b) }
+pub extern "C" fn using_imported_sum3(a: u32, b: u32, c: u32) -> u32 {
+    unsafe { imported_sum3(a, b, c) }
 }

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -113,16 +113,21 @@ defmodule WasmexTest do
   end
 
   describe "when instantiating with imports" do
-    test "call_function: using_imported_sum3(u32, u32, u32) -> (u32) function" do
+    test "call_functions using_imported_sum3 and using_imported_sumf" do
       imports = %{
         "env" => %{
-          "imported_sum3" => {[:i32, :i32, :i32], [:i32], &(&1 + &2 + &3)}
+          "imported_sum3" => {[:i32, :i32, :i32], [:i32], &(&1 + &2 + &3)},
+          "imported_sumf" => {[:f32, :f32], [:f32], &(&1 + &2)}
         }
       }
 
       instance = start_supervised!({Wasmex, %{bytes: @import_test_bytes, imports: imports}})
+
       assert {:ok, [44]} == Wasmex.call_function(instance, "using_imported_sum3", [23, 19, 2])
       assert {:ok, [28]} == Wasmex.call_function(instance, "using_imported_sum3", [100, -77, 5])
+
+      assert {:ok, [4.2]} == Wasmex.call_function(instance, "using_imported_sumf", [2.3, 1.9])
+      assert {:ok, [2.3]} == Wasmex.call_function(instance, "using_imported_sumf", [10.0, -7.7])
     end
   end
 end

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -113,21 +113,30 @@ defmodule WasmexTest do
   end
 
   describe "when instantiating with imports" do
-    test "call_functions using_imported_sum3 and using_imported_sumf" do
+    def create_instance_with_imports(_context) do
       imports = %{
         "env" => %{
           "imported_sum3" => {[:i32, :i32, :i32], [:i32], &(&1 + &2 + &3)},
           "imported_sumf" => {[:f32, :f32], [:f32], &(&1 + &2)}
         }
       }
-
       instance = start_supervised!({Wasmex, %{bytes: @import_test_bytes, imports: imports}})
+      %{instance: instance}
+    end
 
+    setup [:create_instance_with_imports]
+
+    test "call_function using_imported_sum3", %{instance: instance} do
       assert {:ok, [44]} == Wasmex.call_function(instance, "using_imported_sum3", [23, 19, 2])
       assert {:ok, [28]} == Wasmex.call_function(instance, "using_imported_sum3", [100, -77, 5])
+    end
 
-      assert {:ok, [4.2]} == Wasmex.call_function(instance, "using_imported_sumf", [2.3, 1.9])
-      assert {:ok, [2.3]} == Wasmex.call_function(instance, "using_imported_sumf", [10.0, -7.7])
+    test "call_function using_imported_sumf", %{instance: instance} do
+      {:ok, [result]} = Wasmex.call_function(instance, "using_imported_sumf", [2.3, 1.9])
+      assert_in_delta 4.2, result, 0.001
+
+      assert {:ok, [result]} = Wasmex.call_function(instance, "using_imported_sumf", [10.0, -7.7])
+      assert_in_delta 2.3, result, 0.001
     end
   end
 end

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -20,12 +20,12 @@ defmodule WasmexTest do
 
     test "call_function: calling an unknown function", %{instance: instance} do
       assert {:error, "exported function `unknown_function` not found"} =
-              Wasmex.call_function(instance, "unknown_function", [1])
+               Wasmex.call_function(instance, "unknown_function", [1])
     end
 
     test "call_function: arity0 with too many params", %{instance: instance} do
       assert {:error, "number of params does not match. expected 0, got 1"} =
-              Wasmex.call_function(instance, "arity_0", [1])
+               Wasmex.call_function(instance, "arity_0", [1])
     end
 
     test "call_function: arity0 -> i32", %{instance: instance} do
@@ -42,7 +42,7 @@ defmodule WasmexTest do
       # giving a value greater than i32::max_value()
       # see: https://doc.rust-lang.org/std/primitive.i32.html#method.max_value
       assert {:error, "Cannot convert argument #1 to a WebAssembly i32 value."} ==
-              Wasmex.call_function(instance, "i32_i32", [3_000_000_000])
+               Wasmex.call_function(instance, "i32_i32", [3_000_000_000])
     end
 
     test "call_function: i64_i64(i64) -> i64 function", %{instance: instance} do
@@ -62,7 +62,7 @@ defmodule WasmexTest do
 
       # a value greater than f32::max_value()
       assert {:error, "Cannot convert argument #1 to a WebAssembly f32 value."} ==
-              Wasmex.call_function(instance, "f32_f32", [3.5e38])
+               Wasmex.call_function(instance, "f32_f32", [3.5e38])
     end
 
     test "call_function: f64_f64(f64) -> f64 function", %{instance: instance} do
@@ -108,18 +108,21 @@ defmodule WasmexTest do
       Wasmex.Memory.write_binary(memory, index, string)
 
       assert {:ok, [104]} ==
-              Wasmex.call_function(instance, "string_first_byte", [index, String.length(string)])
+               Wasmex.call_function(instance, "string_first_byte", [index, String.length(string)])
     end
   end
 
   describe "when instantiating with imports" do
-    test "call_function: using_imported_function_add_number(u32) -> (u32) function" do
-      imports = %{"env" => %{
-        "imported_sum" => {[:uint8, :uint8], [:uint8], &(&1 + &2)}
-      }}
+    test "call_function: using_imported_sum3(u32, u32, u32) -> (u32) function" do
+      imports = %{
+        "env" => %{
+          "imported_sum3" => {[:i32, :i32, :i32], [:i32], &(&1 + &2 + &3)}
+        }
+      }
+
       instance = start_supervised!({Wasmex, %{bytes: @import_test_bytes, imports: imports}})
-      assert {:ok, [42]} == Wasmex.call_function(instance, "using_imported_sum", [23, 19])
-      assert {:ok, [23]} == Wasmex.call_function(instance, "using_imported_sum", [100, -77])
+      assert {:ok, [44]} == Wasmex.call_function(instance, "using_imported_sum3", [23, 19, 2])
+      assert {:ok, [28]} == Wasmex.call_function(instance, "using_imported_sum3", [100, -77, 5])
     end
   end
 end


### PR DESCRIPTION
Also into strings for the callback token.

This is my first contribution to a rust project, so I am sure what I've written isn't mergeable yet. If you have time to provide feedback then I can address any concerns. 

I decided to use atoms with the same names as the WASM types instead of ones like `:uint8` for memory. Those make sense for memory because the bytes need to be encoded, decoded from the heap, but since these are going onto the stack I think using the WASM types makes sense. However, I can change it if you think it's better to not leak the WASM implementation details out like that.