### PR TITLE
Forward instance memory into elixir callbacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,34 @@
 # Check https://circleci.com/docs/2.0/language-elixir/ for more details on CircleCI configuration
-version: 2
+version: 2.1
+commands:
+  setup-sccache:
+    steps:
+      - run:
+          name: Install sccache
+          command: |
+            source $HOME/.cargo/env
+            cargo install sccache
+            # This configures Rust to use sccache.
+            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
+            # This is the maximum space sccache cache will use on disk.
+            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+            sccache --version
+  restore-sccache-cache:
+    steps:
+      - restore_cache:
+          name: Restore sccache cache
+          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+  save-sccache-cache:
+    steps:
+      - save_cache:
+          name: Save sccache cache
+          # We use {{ epoch }} to always upload a fresh cache:
+          # Of course, restore_cache will not find this exact key,
+          # but it will fall back to the closest key (aka the most recent).
+          # See https://discuss.circleci.com/t/add-mechanism-to-update-existing-cache-key/9014/13
+          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          paths:
+            - "~/.cache/sccache"
 jobs:
   build:
     parallelism: 1
@@ -16,10 +45,6 @@ jobs:
           keys:
             - v1-dependency-cache-{{ checksum "mix.lock" }}
             - v1-dependency-cache
-      - restore_cache:
-          keys:
-            - v1-rust-dependency-cache-{{ checksum "native/wasmex/Cargo.lock" }}
-            - v1-rust-dependency-cache
 
       - run: mix local.hex --force # install Hex locally (without prompt)
       - run: mix local.rebar --force # fetch a copy of rebar (without prompt)
@@ -31,6 +56,8 @@ jobs:
             rustup component add rustfmt
             rustup component add clippy
             rustup target add wasm32-unknown-unknown # to compile our example WASM files for testing
+      - setup-sccache
+      - restore-sccache-cache
 
       - run:
           name: "Run Checks (Tests, Formatters, ..)"
@@ -53,10 +80,7 @@ jobs:
             - deps
             - ~/.mix
 
-      - save_cache:
-          key: v1-rust-dependency-cache-{{ checksum "native/wasmex/Cargo.lock" }}
-          paths:
-            - native/wasmex/target
+      - save-sccache-cache
 
       - store_test_results:
           path: _build/test/lib/wasmex

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,16 @@
 # Check https://circleci.com/docs/2.0/language-elixir/ for more details on CircleCI configuration
 version: 2.1
 commands:
-  setup-sccache:
+  install-rust:
     steps:
       - run:
-          name: Install sccache
+          name: "Install Rust"
           command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y
             source $HOME/.cargo/env
-            cargo install sccache
-            # This configures Rust to use sccache.
-            echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
-            # This is the maximum space sccache cache will use on disk.
-            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
-            sccache --version
-  restore-sccache-cache:
-    steps:
-      - restore_cache:
-          name: Restore sccache cache
-          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
-  save-sccache-cache:
-    steps:
-      - save_cache:
-          name: Save sccache cache
-          # We use {{ epoch }} to always upload a fresh cache:
-          # Of course, restore_cache will not find this exact key,
-          # but it will fall back to the closest key (aka the most recent).
-          # See https://discuss.circleci.com/t/add-mechanism-to-update-existing-cache-key/9014/13
-          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
-          paths:
-            - "~/.cache/sccache"
+            rustup component add rustfmt
+            rustup component add clippy
+            rustup target add wasm32-unknown-unknown # to compile our example WASM files for testing
 jobs:
   build:
     parallelism: 1
@@ -48,16 +30,7 @@ jobs:
 
       - run: mix local.hex --force # install Hex locally (without prompt)
       - run: mix local.rebar --force # fetch a copy of rebar (without prompt)
-      - run:
-          name: "Install Rust"
-          command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y
-            source $HOME/.cargo/env
-            rustup component add rustfmt
-            rustup component add clippy
-            rustup target add wasm32-unknown-unknown # to compile our example WASM files for testing
-      - setup-sccache
-      - restore-sccache-cache
+      - install-rust
 
       - run:
           name: "Run Checks (Tests, Formatters, ..)"
@@ -79,8 +52,6 @@ jobs:
             - _build
             - deps
             - ~/.mix
-
-      - save-sccache-cache
 
       - store_test_results:
           path: _build/test/lib/wasmex

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -54,7 +54,7 @@ defmodule Wasmex do
 
   When the WASM code executes the `add_ints` imported function, the execution context is forwarded to
   the given function reference.
-  The first param is always the call context (containing e.g. the instances memory).
+  The first param is always the call context (a Map containing e.g. the instances memory).
   All other params are regular parameters as specified by the parameter type list.
 
   Valid parameter/return types are:
@@ -170,6 +170,13 @@ defmodule Wasmex do
         {:invoke_callback, namespace_name, import_name, context, params, token},
         %{imports: imports} = state
       ) do
+    context =
+      Map.put(
+        context,
+        :memory,
+        Wasmex.Memory.wrap_resource(Map.get(context, :memory), :uint8, 0)
+      )
+
     {success, return_value} =
       try do
         {:fn, _params, _returns, callback} =

--- a/lib/wasmex/memory.ex
+++ b/lib/wasmex/memory.ex
@@ -72,7 +72,7 @@ defmodule Wasmex.Memory do
     end
   end
 
-  defp wrap_resource(resource, size, offset) do
+  def wrap_resource(resource, size, offset) do
     %__MODULE__{
       resource: resource,
       reference: make_ref(),

--- a/native/wasmex/src/atoms.rs
+++ b/native/wasmex/src/atoms.rs
@@ -23,6 +23,9 @@ rustler::rustler_atoms! {
     atom params;
     atom results;
 
+    // callback context
+    atom memory;
+
     // calls to erlang processes
     atom returned_function_call;
     atom invoke_callback;

--- a/test/wasmex/instance_test.exs
+++ b/test/wasmex/instance_test.exs
@@ -113,7 +113,7 @@ defmodule Wasmex.InstanceTest do
       receive do
         {:returned_function_call, {:ok, [42]}, :fake_from} -> nil
       after
-        1000 ->
+        2000 ->
           raise "message_expected"
       end
     end


### PR DESCRIPTION
* Refactor the rust-implementation of `memory` to not depend on an instance.
* Inject the instances memory into the callback context