### PR TITLE
New way to read and write binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Given we have the following Rust function in our WebAssembly (copied from our te
 ```rust
 #[no_mangle]
 pub extern "C" fn string() -> *const u8 {
-    b"Hello, World!\0".as_ptr()
+    b"Hello, World!".as_ptr()
 }
 ```
 
@@ -275,7 +275,7 @@ bytes = File.read!(TestHelper.wasm_test_file_path)
 {:ok, memory} = Wasmex.memory(instance, :uint8, 0)
 
 {:ok, [pointer]} = Wasmex.call_function(instance, "string", [])
-returned_string = Wasmex.Memory.read_binary(memory, pointer) # "Hello, World!"
+returned_string = Wasmex.Memory.read_string(memory, pointer, 13) # "Hello, World!"
 ```
 
 # Endianness of WASM Values

--- a/lib/wasmex/memory.ex
+++ b/lib/wasmex/memory.ex
@@ -193,7 +193,7 @@ defmodule Wasmex.Memory do
     Wasmex.Native.memory_write_binary(resource, size, offset, index, str)
   end
 
-  @spec read_binary(__MODULE__.t(), non_neg_integer(), non_neg_integer()) :: binary()
+  @spec read_binary(t, non_neg_integer(), non_neg_integer()) :: binary()
   def read_binary(%Wasmex.Memory{} = memory, index, length) do
     read_binary(memory, memory.size, memory.offset, index, length)
   end
@@ -206,8 +206,27 @@ defmodule Wasmex.Memory do
           non_neg_integer()
         ) ::
           binary()
-  def read_binary(%Wasmex.Memory{resource: resource}, size, offset, index, length) do
+  def read_binary(%__MODULE__{resource: resource}, size, offset, index, length) do
     Wasmex.Native.memory_read_binary(resource, size, offset, index, length)
+  end
+
+  @spec read_string(t, non_neg_integer(), non_neg_integer()) :: String.t()
+  def read_string(memory, index, length) do
+    read_binary(memory, index, length)
+    |> to_string()
+  end
+
+  @spec read_string(
+          t,
+          atom(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          String.t()
+  def read_string(memory, size, offset, index, length) do
+    read_binary(memory, size, offset, index, length)
+    |> to_string()
   end
 end
 

--- a/lib/wasmex/memory.ex
+++ b/lib/wasmex/memory.ex
@@ -198,8 +198,6 @@ defmodule Wasmex.Memory do
     read_binary(memory, memory.size, memory.offset, index, length)
   end
 
-  def read_binary(_memory, _size, _offset, _index, 0), do: <<>>
-
   @spec read_binary(
           __MODULE__.t(),
           atom(),

--- a/lib/wasmex/memory.ex
+++ b/lib/wasmex/memory.ex
@@ -57,13 +57,13 @@ defmodule Wasmex.Memory do
             size: nil,
             offset: nil
 
-  @spec from_instance(Wasmex.Instance.t()) :: {:error, binary()} | {:ok, __MODULE__.t()}
+  @spec from_instance(Wasmex.Instance.t()) :: {:error, binary()} | {:ok, t}
   def from_instance(%Wasmex.Instance{} = instance) do
     from_instance(instance, :uint8, 0)
   end
 
   @spec from_instance(Wasmex.Instance.t(), atom(), non_neg_integer()) ::
-          {:error, binary()} | {:ok, __MODULE__.t()}
+          {:error, binary()} | {:ok, t}
   def from_instance(%Wasmex.Instance{resource: resource}, size, offset)
       when size in [:uint8, :int8, :uint16, :int16, :uint32, :int32] do
     case Wasmex.Native.memory_from_instance(resource) do
@@ -100,8 +100,8 @@ defmodule Wasmex.Memory do
   Wasmex.Memory.bytes_per_element(memory) # 2
   ```
   """
-  @spec bytes_per_element(__MODULE__.t()) :: pos_integer()
-  def bytes_per_element(%Wasmex.Memory{} = memory) do
+  @spec bytes_per_element(t) :: pos_integer()
+  def bytes_per_element(%__MODULE__{} = memory) do
     bytes_per_element(memory, memory.size, memory.offset)
   end
 
@@ -113,8 +113,8 @@ defmodule Wasmex.Memory do
   Wasmex.Memory.bytes_per_element(memory, :uint32, 0) # 4
   ```
   """
-  @spec bytes_per_element(__MODULE__.t(), atom(), non_neg_integer()) :: pos_integer()
-  def bytes_per_element(%Wasmex.Memory{resource: resource}, size, offset) do
+  @spec bytes_per_element(t, atom(), non_neg_integer()) :: pos_integer()
+  def bytes_per_element(%__MODULE__{resource: resource}, size, offset) do
     Wasmex.Native.memory_bytes_per_element(resource, size, offset)
   end
 
@@ -129,8 +129,8 @@ defmodule Wasmex.Memory do
   Wasmex.Memory.length(memory) # 1114112 (17 * 65_536)
   ```
   """
-  @spec length(__MODULE__.t()) :: pos_integer()
-  def length(%Wasmex.Memory{} = memory) do
+  @spec length(t) :: pos_integer()
+  def length(%__MODULE__{} = memory) do
     length(memory, memory.size, memory.offset)
   end
 
@@ -142,8 +142,8 @@ defmodule Wasmex.Memory do
   Wasmex.Memory.length(memory, :uint8, 0) # 1114112 (17 * 65_536)
   ```
   """
-  @spec length(__MODULE__.t(), atom(), non_neg_integer()) :: pos_integer()
-  def length(%Wasmex.Memory{resource: resource}, size, offset) do
+  @spec length(t, atom(), non_neg_integer()) :: pos_integer()
+  def length(%__MODULE__{resource: resource}, size, offset) do
     Wasmex.Native.memory_length(resource, size, offset)
   end
 
@@ -151,44 +151,44 @@ defmodule Wasmex.Memory do
   Grows the amount of available memory by the given number of pages and returns the number of previously available pages.
   Note that the maximum number of pages is `65_536`
   """
-  @spec grow(__MODULE__.t(), pos_integer()) :: pos_integer()
-  def grow(%Wasmex.Memory{} = memory, pages) do
+  @spec grow(t, pos_integer()) :: pos_integer()
+  def grow(%__MODULE__{} = memory, pages) do
     grow(memory, memory.size, memory.offset, pages)
   end
 
-  @spec grow(__MODULE__.t(), atom(), non_neg_integer(), pos_integer()) :: pos_integer()
-  def grow(%Wasmex.Memory{resource: resource}, size, offset, pages) do
+  @spec grow(t, atom(), non_neg_integer(), pos_integer()) :: pos_integer()
+  def grow(%__MODULE__{resource: resource}, size, offset, pages) do
     Wasmex.Native.memory_grow(resource, size, offset, pages)
   end
 
-  @spec get(__MODULE__.t(), pos_integer()) :: number()
-  def get(%Wasmex.Memory{} = memory, index) do
+  @spec get(t, pos_integer()) :: number()
+  def get(%__MODULE__{} = memory, index) do
     get(memory, memory.size, memory.offset, index)
   end
 
-  @spec get(__MODULE__.t(), atom(), non_neg_integer(), pos_integer()) :: number()
-  def get(%Wasmex.Memory{resource: resource}, size, offset, index) do
+  @spec get(t, atom(), non_neg_integer(), pos_integer()) :: number()
+  def get(%__MODULE__{resource: resource}, size, offset, index) do
     Wasmex.Native.memory_get(resource, size, offset, index)
   end
 
-  @spec set(__MODULE__.t(), non_neg_integer(), number()) :: number()
-  def set(%Wasmex.Memory{} = memory, index, value) do
+  @spec set(t, non_neg_integer(), number()) :: number()
+  def set(%__MODULE__{} = memory, index, value) do
     set(memory, memory.size, memory.offset, index, value)
   end
 
-  @spec set(__MODULE__.t(), atom(), non_neg_integer(), non_neg_integer(), number()) :: number()
-  def set(%Wasmex.Memory{resource: resource}, size, offset, index, value) do
+  @spec set(t, atom(), non_neg_integer(), non_neg_integer(), number()) :: number()
+  def set(%__MODULE__{resource: resource}, size, offset, index, value) do
     Wasmex.Native.memory_set(resource, size, offset, index, value)
   end
 
-  @spec write_binary(__MODULE__.t(), non_neg_integer(), binary()) :: :ok
-  def write_binary(%Wasmex.Memory{} = memory, index, str) when is_binary(str) do
+  @spec write_binary(t, non_neg_integer(), binary()) :: :ok
+  def write_binary(%__MODULE__{} = memory, index, str) when is_binary(str) do
     write_binary(memory, memory.size, memory.offset, index, str)
   end
 
-  @spec write_binary(__MODULE__.t(), atom(), non_neg_integer(), non_neg_integer(), binary()) ::
+  @spec write_binary(t, atom(), non_neg_integer(), non_neg_integer(), binary()) ::
           :ok
-  def write_binary(%Wasmex.Memory{resource: resource}, size, offset, index, str)
+  def write_binary(%__MODULE__{resource: resource}, size, offset, index, str)
       when is_binary(str) do
     Wasmex.Native.memory_write_binary(resource, size, offset, index, str)
   end

--- a/lib/wasmex/memory.ex
+++ b/lib/wasmex/memory.ex
@@ -190,21 +190,26 @@ defmodule Wasmex.Memory do
           :ok
   def write_binary(%Wasmex.Memory{resource: resource}, size, offset, index, str)
       when is_binary(str) do
-    # strings a null-byte terminated in C-land
-    str = str <> "\0"
     Wasmex.Native.memory_write_binary(resource, size, offset, index, str)
   end
 
-  @spec read_binary(__MODULE__.t(), non_neg_integer()) :: binary()
-  def read_binary(%Wasmex.Memory{} = memory, index) do
-    read_binary(memory, memory.size, memory.offset, index)
+  @spec read_binary(__MODULE__.t(), non_neg_integer(), non_neg_integer()) :: binary()
+  def read_binary(%Wasmex.Memory{} = memory, index, length) do
+    read_binary(memory, memory.size, memory.offset, index, length)
   end
 
-  @spec read_binary(__MODULE__.t(), atom(), non_neg_integer(), non_neg_integer()) :: binary()
-  def read_binary(%Wasmex.Memory{resource: resource}, size, offset, index) do
-    Wasmex.Native.memory_read_binary(resource, size, offset, index)
-    |> to_string
-    |> String.trim_trailing("\0")
+  def read_binary(_memory, _size, _offset, _index, 0), do: <<>>
+
+  @spec read_binary(
+          __MODULE__.t(),
+          atom(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) ::
+          binary()
+  def read_binary(%Wasmex.Memory{resource: resource}, size, offset, index, length) do
+    Wasmex.Native.memory_read_binary(resource, size, offset, index, length)
   end
 end
 

--- a/lib/wasmex/native.ex
+++ b/lib/wasmex/native.ex
@@ -16,7 +16,7 @@ defmodule Wasmex.Native do
   def memory_grow(_resource, _size, _offset, _pages), do: error()
   def memory_get(_resource, _size, _offset, _index), do: error()
   def memory_set(_resource, _size, _offset, _index, _value), do: error()
-  def memory_read_binary(_resource, _size, _offset, _index), do: error()
+  def memory_read_binary(_resource, _size, _offset, _index, _length), do: error()
   def memory_write_binary(_resource, _size, _offset, _index, _binary), do: error()
 
   # When the NIF is loaded, it will override functions in this module.

--- a/native/wasmex/src/lib.rs
+++ b/native/wasmex/src/lib.rs
@@ -24,7 +24,7 @@ rustler::rustler_export_nifs! {
         ("memory_grow", 4, memory::grow),
         ("memory_get", 4, memory::get),
         ("memory_set", 5, memory::set),
-        ("memory_read_binary", 4, memory::read_binary),
+        ("memory_read_binary", 5, memory::read_binary),
         ("memory_write_binary", 5, memory::write_binary),
     ],
     Some(on_load)

--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -200,17 +200,21 @@ pub fn read_binary<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Erro
     let (resource, size, offset) = extract_params(args)?;
     let memory = resource.memory.lock().unwrap();
     let index: usize = args[3].decode()?;
+    let length: usize = args[4].decode()?;
     let index = bounds_checked_index(&memory, size, offset, index)?;
     let view = memory.view::<u8>();
 
-    if offset + index >= view.len() {
+    let start = offset + index;
+    let end = offset + index + length;
+
+    if end > view.len() {
         return Err(Error::RaiseTerm(Box::new(
             "Out of bound: The given binary will write out of memory",
         )));
     }
 
     let mut binary: Vec<u8> = Vec::new();
-    for i in (offset + index)..view.len() {
+    for i in start..end {
         let value = view[i].get();
         binary.push(value);
         if value == 0 {

--- a/test/wasmex/memory_test.exs
+++ b/test/wasmex/memory_test.exs
@@ -125,7 +125,7 @@ defmodule Wasmex.MemoryTest do
   end
 
   describe "read_binary/2" do
-    test "reads a string from memory" do
+    test "reads a binary from memory" do
       {:ok, memory} = build_memory(:uint8, 0)
       # h
       Wasmex.Memory.set(memory, 0, 104)
@@ -140,7 +140,27 @@ defmodule Wasmex.MemoryTest do
 
       assert Wasmex.Memory.read_binary(memory, 0, 5) == 'hello'
       assert Wasmex.Memory.read_binary(memory, 3, 2) == 'lo'
-      assert Wasmex.Memory.read_binary(memory, 8, 0) == <<>>
+      assert Wasmex.Memory.read_binary(memory, 8, 0) == ''
+    end
+  end
+
+  describe "read_string/2" do
+    test "reads a string from memory" do
+      {:ok, memory} = build_memory(:uint8, 0)
+      # h
+      Wasmex.Memory.set(memory, 0, 104)
+      # e
+      Wasmex.Memory.set(memory, 1, 101)
+      # l
+      Wasmex.Memory.set(memory, 2, 108)
+      # l
+      Wasmex.Memory.set(memory, 3, 108)
+      # o
+      Wasmex.Memory.set(memory, 4, 111)
+
+      assert Wasmex.Memory.read_string(memory, 0, 5) == "hello"
+      assert Wasmex.Memory.read_string(memory, 3, 2) == "lo"
+      assert Wasmex.Memory.read_string(memory, 8, 0) == ""
     end
   end
 end

--- a/test/wasmex/memory_test.exs
+++ b/test/wasmex/memory_test.exs
@@ -110,8 +110,6 @@ defmodule Wasmex.MemoryTest do
       assert Wasmex.Memory.get(memory, 3) == 108
       # o
       assert Wasmex.Memory.get(memory, 4) == 111
-      # automatically added null byte
-      assert Wasmex.Memory.get(memory, 5) == 0
 
       # overwriting the same area in memory to see if the automatic null byte is being added
       :ok = Wasmex.Memory.write_binary(memory, 1, "abc")
@@ -123,8 +121,6 @@ defmodule Wasmex.MemoryTest do
       assert Wasmex.Memory.get(memory, 2) == 98
       # c
       assert Wasmex.Memory.get(memory, 3) == 99
-      # automatically added null byte
-      assert Wasmex.Memory.get(memory, 4) == 0
     end
   end
 
@@ -141,12 +137,10 @@ defmodule Wasmex.MemoryTest do
       Wasmex.Memory.set(memory, 3, 108)
       # o
       Wasmex.Memory.set(memory, 4, 111)
-      # automatically added null byte
-      Wasmex.Memory.set(memory, 5, 0)
 
-      assert Wasmex.Memory.read_binary(memory, 0) == "hello"
-      assert Wasmex.Memory.read_binary(memory, 3) == "lo"
-      assert Wasmex.Memory.read_binary(memory, 8) == ""
+      assert Wasmex.Memory.read_binary(memory, 0, 5) == 'hello'
+      assert Wasmex.Memory.read_binary(memory, 3, 2) == 'lo'
+      assert Wasmex.Memory.read_binary(memory, 8, 0) == <<>>
     end
   end
 end

--- a/test/wasmex/memory_test.exs
+++ b/test/wasmex/memory_test.exs
@@ -124,7 +124,7 @@ defmodule Wasmex.MemoryTest do
     end
   end
 
-  describe "read_binary/2" do
+  describe "read_binary/3" do
     test "reads a binary from memory" do
       {:ok, memory} = build_memory(:uint8, 0)
       # h
@@ -144,7 +144,7 @@ defmodule Wasmex.MemoryTest do
     end
   end
 
-  describe "read_string/2" do
+  describe "read_string/3" do
     test "reads a string from memory" do
       {:ok, memory} = build_memory(:uint8, 0)
       # h

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -101,7 +101,7 @@ defmodule WasmexTest do
     test "call_function: string() -> string function", %{instance: instance} do
       {:ok, [pointer]} = Wasmex.call_function(instance, :string, [])
       {:ok, memory} = Wasmex.memory(instance, :uint8, 0)
-      returned_string = Wasmex.Memory.read_binary(memory, pointer)
+      returned_string = Wasmex.Memory.read_binary(memory, pointer, 13) |> to_string()
       assert returned_string == "Hello, World!"
     end
 

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -101,8 +101,7 @@ defmodule WasmexTest do
     test "call_function: string() -> string function", %{instance: instance} do
       {:ok, [pointer]} = Wasmex.call_function(instance, :string, [])
       {:ok, memory} = Wasmex.memory(instance, :uint8, 0)
-      returned_string = Wasmex.Memory.read_binary(memory, pointer, 13) |> to_string()
-      assert returned_string == "Hello, World!"
+      assert Wasmex.Memory.read_string(memory, pointer, 13) == "Hello, World!"
     end
 
     test "call_function: string_first_byte(string_pointer) -> u8 function", %{instance: instance} do


### PR DESCRIPTION
* Writing binaries is no longer null terminated
* Reading binaries returns a charlist/bitstring depending on the bytes
* Reading binaries requires a length (I don't have many use cases where I want to consume the entire memory of the wasm vm)
* Reading strings reads a binary and pipes to `to_string`

Binaries are useful for communicating files or ciphers into/out of the wasm VM while strings are more useful for text communication so I think it's important to support both easily.

TODO:

- [x] Should there be an option to read the entire memory by pre-filling in the memory view's length?
- [x] Should there be a `read_string` which pipes to `to_string()`? (I don't mind doing this myself, but is it a nice thing to offer?)

If you get time, I'd appreciate your thoughts @tessi 