### PR TITLE
Non-string binaries in memory

### DIFF
--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -239,7 +239,7 @@ pub fn write_binary<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Err
         )));
     }
 
-    for (i, byte) in binary.into_iter().enumerate() {
+    for (i, byte) in binary.iter().enumerate() {
         view[offset + index + i].set(*byte)
     }
     Ok(atoms::ok().encode(env))

--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -215,10 +215,12 @@ pub fn read_binary<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Erro
 
     let mut binary: OwnedBinary = OwnedBinary::new(length).unwrap();
 
-    for i in start..end {
-        let value = view[i].get();
-        binary[i - start] = value;
-    }
+    let data = view[start..end]
+        .into_iter()
+        .map(|cell| cell.get())
+        .collect::<Vec<u8>>();
+
+    binary.copy_from_slice(&data);
 
     let final_binary: Binary = Binary::from_owned(binary, env);
 

--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -3,7 +3,7 @@
 use std::sync::Mutex;
 
 use rustler::resource::ResourceArc;
-use rustler::{Encoder, Env, Error, Term, Binary, OwnedBinary};
+use rustler::{Binary, Encoder, Env, Error, OwnedBinary, Term};
 use wasmer_runtime::{self as runtime, Export, Memory};
 use wasmer_runtime_core::units::Pages;
 

--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -216,7 +216,7 @@ pub fn read_binary<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Erro
     let mut binary: OwnedBinary = OwnedBinary::new(length).unwrap();
 
     let data = view[start..end]
-        .into_iter()
+        .iter()
         .map(|cell| cell.get())
         .collect::<Vec<u8>>();
 

--- a/test/wasmex/memory_test.exs
+++ b/test/wasmex/memory_test.exs
@@ -97,7 +97,7 @@ defmodule Wasmex.MemoryTest do
   end
 
   describe "write_binary/3" do
-    test "writes a string into memory" do
+    test "writes a binary into memory" do
       {:ok, memory} = build_memory(:uint8, 0)
       :ok = Wasmex.Memory.write_binary(memory, 0, "hello")
       # h
@@ -121,6 +121,12 @@ defmodule Wasmex.MemoryTest do
       assert Wasmex.Memory.get(memory, 2) == 98
       # c
       assert Wasmex.Memory.get(memory, 3) == 99
+
+      random_bytes = :crypto.strong_rand_bytes(24)
+      # writing random bytes is fine as well
+      :ok = Wasmex.Memory.write_binary(memory, 0, random_bytes)
+      # should also be able to read it back
+      assert Wasmex.Memory.read_binary(memory, 0, 24) == random_bytes
     end
   end
 

--- a/test/wasmex/memory_test.exs
+++ b/test/wasmex/memory_test.exs
@@ -144,9 +144,9 @@ defmodule Wasmex.MemoryTest do
       # o
       Wasmex.Memory.set(memory, 4, 111)
 
-      assert Wasmex.Memory.read_binary(memory, 0, 5) == 'hello'
-      assert Wasmex.Memory.read_binary(memory, 3, 2) == 'lo'
-      assert Wasmex.Memory.read_binary(memory, 8, 0) == ''
+      assert Wasmex.Memory.read_binary(memory, 0, 5) == "hello"
+      assert Wasmex.Memory.read_binary(memory, 3, 2) == "lo"
+      assert Wasmex.Memory.read_binary(memory, 8, 0) == ""
     end
   end
 


### PR DESCRIPTION
The current `read`/`write_binary` functions only work with valid strings. This changes to use rustler's `Binary` for reading and writing / encoding and decoding. I'll be honest the for loop with the `binary[i - start]` is pretty ugly to me, but I couldn't think of a better way to do it.