### PR TITLE
Memory indexes can be zero

### DIFF
--- a/lib/wasmex/memory.ex
+++ b/lib/wasmex/memory.ex
@@ -161,12 +161,12 @@ defmodule Wasmex.Memory do
     Wasmex.Native.memory_grow(resource, size, offset, pages)
   end
 
-  @spec get(t, pos_integer()) :: number()
+  @spec get(t, non_neg_integer()) :: number()
   def get(%__MODULE__{} = memory, index) do
     get(memory, memory.size, memory.offset, index)
   end
 
-  @spec get(t, atom(), non_neg_integer(), pos_integer()) :: number()
+  @spec get(t, atom(), non_neg_integer(), non_neg_integer()) :: number()
   def get(%__MODULE__{resource: resource}, size, offset, index) do
     Wasmex.Native.memory_get(resource, size, offset, index)
   end


### PR DESCRIPTION
A small change to the type specs. Dialyzer isn't checking the `.exs` files so it didn't catch the tests where zero was used.