### PR TITLE
Removing unsafe from value conversion

### DIFF
--- a/native/wasmex/src/environment.rs
+++ b/native/wasmex/src/environment.rs
@@ -11,7 +11,7 @@ use wasmer::{
 
 use crate::{
     atoms,
-    instance::{map_to_wasmer_values, RustValue},
+    instance::{map_to_wasmer_values, WasmValue},
     memory::MemoryResource,
 };
 
@@ -29,7 +29,7 @@ pub struct CallbackTokenResource {
 pub struct CallbackToken {
     pub continue_signal: Condvar,
     pub return_types: Vec<Type>,
-    pub return_values: Mutex<Option<(bool, Vec<RustValue>)>>,
+    pub return_values: Mutex<Option<(bool, Vec<WasmValue>)>>,
 }
 
 impl Environment {
@@ -198,11 +198,11 @@ impl Environment {
                     result = callback_token.token.continue_signal.wait(result).unwrap();
                 }
 
-                let result: &(bool, Vec<RustValue>) = result
+                let result: &(bool, Vec<WasmValue>) = result
                     .as_ref()
                     .expect("expect callback token to contain a result");
                 match result {
-                    (true, v) => Ok(map_to_wasmer_values(v.to_vec())),
+                    (true, v) => Ok(map_to_wasmer_values(v)),
                     (false, _) => Err(RuntimeError::new("the elixir callback threw an exception")),
                 }
             },

--- a/native/wasmex/src/instance.rs
+++ b/native/wasmex/src/instance.rs
@@ -9,7 +9,7 @@ use rustler::{
 use std::sync::Mutex;
 use std::thread;
 
-use wasmer::{Instance, Module, Store, Type, Value, Val};
+use wasmer::{Instance, Module, Store, Type, Val, Value};
 
 use crate::{
     atoms, environment::Environment, functions, memory::memory_from_instance,
@@ -217,7 +217,7 @@ pub fn decode_function_param_terms(
                             nth + 1
                         ));
                     }
-                },
+                }
                 Err(_) => {
                     return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly f32 value.",

--- a/native/wasmex/src/printable_term_type.rs
+++ b/native/wasmex/src/printable_term_type.rs
@@ -1,6 +1,6 @@
 use rustler::dynamic::TermType;
 
-// PrintableTermType is a workaround for ustler::dynamic::TermType not having the Debug trait.
+// PrintableTermType is a workaround for rustler::dynamic::TermType not having the Debug trait.
 pub enum PrintableTermType {
     PrintTerm(TermType),
 }


### PR DESCRIPTION
`Enum` in Rust seems to be right enough to store a value and a type together