### PR TITLE
Support `target.aarch64-apple-darwin`

### DIFF
--- a/native/wasmex/.cargo/config
+++ b/native/wasmex/.cargo/config
@@ -3,3 +3,9 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-apple-darwin]
+ rustflags = [
+     "-C", "link-arg=-undefined",
+     "-C", "link-arg=dynamic_lookup",
+ ]


### PR DESCRIPTION
Hello, I am having trouble compiling Wasmex for my Aarch64-darwin CPU. When I run `mix test` on my project, I get the following error:

```
                rustler::types::tuple::make_tuple::h8c2393e1a45d3d38 in librustler-8635bf1d8b765849.rlib(rustler-8635bf1d8b765849.rustler.e7e4hp6d-cgu.11.rcgu.o)
                rustler::types::tuple::_$LT$impl$u20$rustler..types..Encoder$u20$for$u20$$LP$$RP$$GT$::encode::hf6cc205a13956d93 in librustler-8635bf1d8b765849.rlib(rustler-8635bf1d8b765849.rustler.e7e4hp6d-cgu.11.rcgu.o)
                rustler::wrapper::tuple::make_tuple::hd5746784462fd12c in librustler-8635bf1d8b765849.rlib(rustler-8635bf1d8b765849.rustler.e7e4hp6d-cgu.15.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: aborting due to previous error

error: could not compile `wasmex`

To learn more, run the command again with --verbose.
could not compile dependency :wasmex, "mix compile" failed. You can recompile this dependency with "mix deps.compile wasmex", update it with "mix deps.update wasmex" or clean it with "mix deps.clean wasmex"
```

It seems like this is due to Rustler not supporting an `aarch64-darwin` configuration in Cargo - See this issue: https://github.com/avencera/fast_rss/pull/7 and their fix: https://github.com/avencera/fast_rss/pull/8 in `fast_rss`.

I've gone ahead and added in their fix and it seems to also work for Wasmex. I ran all of the CI tests locally and they are now passing - would it be possible to merge this into the main branch? Thanks!