### PR TITLE
Split module compilation from instance creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,14 @@ Types of changes
 
 ## [unreleased changes]
 
--- add your changes here
+### Added
 
+* `Wasmex.Module.compile/1` which can take the bytes of a .wasm files and compiles the WASM module. This module can be given to the new methods `Wasmex.Instance.new/2` and `Wasmex.Instance.new_wasi/3` allowing to re-used precompiled modules. This has a big potential speed-up if one wishes to run a WASI instance multiple times. For example, the wasmex test suite went from 14.5s to just 0.2s runtime.
+* `Wasmex.start_link` can now also be called with a precompiled module in addition to the .wasm file bytes.
+
+### Deprecated
+
+* `Instance.from_bytes/2` and `Instance.wasi_from_bytes/3` are deprecated in favor of `Wasmex.Instance.new/2` and `Wasmex.Instance.new_wasi/3`. Both may be removed in any release after this one.
 ## [0.5.0] - 2021-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ This WASM file can be executed in Elixir:
 
 ```elixir
 {:ok, bytes } = File.read("wasmex_test.wasm")
-{:ok, instance } = Wasmex.start_link(%{bytes: bytes}) # starts a GenServer running this WASM instance
+{:ok, module} = Wasmex.Module.compile(bytes)
+{:ok, instance } = Wasmex.start_link(%{module: module}) # starts a GenServer running this WASM instance
 
 {:ok, [42]} == Wasmex.call_function(instance, "sum", [50, -8])
 ```

--- a/lib/wasmex/callback_token.ex
+++ b/lib/wasmex/callback_token.ex
@@ -1,7 +1,5 @@
 defmodule Wasmex.CallbackToken do
-  @moduledoc """
-  Used internally within Wasmex to help implement function imports.
-  """
+  @moduledoc false
 
   @type t :: %__MODULE__{
           resource: binary(),
@@ -14,7 +12,6 @@ defmodule Wasmex.CallbackToken do
             # resource in attributes. This will convert the resource into an
             # empty binary with no warning. This will make that harder to
             # accidentally do.
-            # It also serves as a handy way to tell file handles apart.
             reference: nil
 
   def wrap_resource(resource) do

--- a/lib/wasmex/memory.ex
+++ b/lib/wasmex/memory.ex
@@ -95,7 +95,6 @@ defmodule Wasmex.Memory do
             # resource in attributes. This will convert the resource into an
             # empty binary with no warning. This will make that harder to
             # accidentally do.
-            # It also serves as a handy way to tell file handles apart.
             reference: nil,
             size: nil,
             offset: nil

--- a/lib/wasmex/module.ex
+++ b/lib/wasmex/module.ex
@@ -1,0 +1,48 @@
+defmodule Wasmex.Module do
+  @moduledoc """
+  A compiled WebAssembly module.
+
+      # Read a WASM file and compile it into a WASM module
+      {:ok, bytes } = File.read("wasmex_test.wasm")
+      {:ok, module} = Wasmex.Module.compile(bytes)
+
+      # use the compiled module to start as many running instances as you want
+      {:ok, instance } = Wasmex.start_link(%{module: module})
+  """
+
+  @type t :: %__MODULE__{
+          resource: binary(),
+          reference: reference()
+        }
+
+  defstruct resource: nil,
+            # The actual NIF module resource.
+            # Normally the compiler will happily do stuff like inlining the
+            # resource in attributes. This will convert the resource into an
+            # empty binary with no warning. This will make that harder to
+            # accidentally do.
+            reference: nil
+
+  @spec compile(binary()) :: {:error, binary()} | {:ok, __MODULE__.t()}
+  def compile(bytes) when is_binary(bytes) do
+    case Wasmex.Native.module_compile(bytes) do
+      {:ok, resource} -> {:ok, wrap_resource(resource)}
+      {:error, err} -> {:error, err}
+    end
+  end
+
+  defp wrap_resource(resource) do
+    %__MODULE__{
+      resource: resource,
+      reference: make_ref()
+    }
+  end
+end
+
+defimpl Inspect, for: Wasmex.Module do
+  import Inspect.Algebra
+
+  def inspect(dict, opts) do
+    concat(["#Wasmex.Module<", to_doc(dict.reference, opts), ">"])
+  end
+end

--- a/lib/wasmex/native.ex
+++ b/lib/wasmex/native.ex
@@ -1,29 +1,30 @@
 defmodule Wasmex.Native do
-  @moduledoc """
-  Contains calls that are implemented in our Rust NIF.
-  Functions in this module are not intended to be called directly.
-  """
+  @moduledoc false
 
   use Rustler, otp_app: :wasmex
 
-  def instance_new_from_bytes(_bytes, _imports), do: error()
-  def instance_new_wasi_from_bytes(_bytes, _imports, _args, _env, _opts), do: error()
-  def instance_function_export_exists(_resource, _function_name), do: error()
-  def instance_call_exported_function(_resource, _function_name, _params, _from), do: error()
+  def module_compile(_bytes), do: error()
+  def instance_new(_module_resource, _imports), do: error()
+  def instance_new_wasi(_module_resource, _imports, _args, _env, _opts), do: error()
+  def instance_function_export_exists(_instance_resource, _function_name), do: error()
+
+  def instance_call_exported_function(_instance_resource, _function_name, _params, _from),
+    do: error()
+
   def namespace_receive_callback_result(_callback_token, _success, _params), do: error()
-  def memory_from_instance(_resource), do: error()
+  def memory_from_instance(_memory_resource), do: error()
   def memory_bytes_per_element(_size), do: error()
-  def memory_length(_resource, _size, _offset), do: error()
-  def memory_grow(_resource, _pages), do: error()
-  def memory_get(_resource, _size, _offset, _index), do: error()
-  def memory_set(_resource, _size, _offset, _index, _value), do: error()
-  def memory_read_binary(_resource, _size, _offset, _index, _length), do: error()
-  def memory_write_binary(_resource, _size, _offset, _index, _binary), do: error()
+  def memory_length(_memory_resource, _size, _offset), do: error()
+  def memory_grow(_memory_resource, _pages), do: error()
+  def memory_get(_memory_resource, _size, _offset, _index), do: error()
+  def memory_set(_memory_resource, _size, _offset, _index, _value), do: error()
+  def memory_read_binary(_memory_resource, _size, _offset, _index, _length), do: error()
+  def memory_write_binary(_memory_resource, _size, _offset, _index, _binary), do: error()
   def pipe_create(), do: error()
-  def pipe_size(_resource), do: error()
-  def pipe_set_len(_resource, _len), do: error()
-  def pipe_read_binary(_resource), do: error()
-  def pipe_write_binary(_resource, _binary), do: error()
+  def pipe_size(_pipe_resource), do: error()
+  def pipe_set_len(_pipe_resource, _len), do: error()
+  def pipe_read_binary(_pipe_resource), do: error()
+  def pipe_write_binary(_pipe_resource, _binary), do: error()
 
   # When the NIF is loaded, it will override functions in this module.
   # Calling error is handles the case when the nif could not be loaded.

--- a/lib/wasmex/pipe.ex
+++ b/lib/wasmex/pipe.ex
@@ -10,12 +10,11 @@ defmodule Wasmex.Pipe do
         }
 
   defstruct resource: nil,
-            # The actual NIF CallbackToken resource.
+            # The actual NIF pipe resource.
             # Normally the compiler will happily do stuff like inlining the
             # resource in attributes. This will convert the resource into an
             # empty binary with no warning. This will make that harder to
             # accidentally do.
-            # It also serves as a handy way to tell file handles apart.
             reference: nil
 
   def wrap_resource(resource) do

--- a/native/wasmex/src/lib.rs
+++ b/native/wasmex/src/lib.rs
@@ -3,6 +3,7 @@ pub mod environment;
 pub mod functions;
 pub mod instance;
 pub mod memory;
+pub mod module;
 pub mod namespace;
 pub mod pipe;
 pub mod printable_term_type;
@@ -16,8 +17,9 @@ use rustler::{Env, Term};
 rustler::init! {
     "Elixir.Wasmex.Native",
     [
-        instance::new_from_bytes,
-        instance::new_wasi_from_bytes,
+        module::compile,
+        instance::new,
+        instance::new_wasi,
         instance::function_export_exists,
         instance::call_exported_function,
         namespace::receive_callback_result,
@@ -40,6 +42,7 @@ rustler::init! {
 
 fn on_load(env: Env, _info: Term) -> bool {
     rustler::resource!(instance::InstanceResource, env);
+    rustler::resource!(module::ModuleResource, env);
     rustler::resource!(memory::MemoryResource, env);
     rustler::resource!(environment::CallbackTokenResource, env);
     rustler::resource!(pipe::PipeResource, env);

--- a/native/wasmex/src/module.rs
+++ b/native/wasmex/src/module.rs
@@ -1,0 +1,37 @@
+use rustler::{resource::ResourceArc, types::binary::Binary, NifResult};
+use std::sync::Mutex;
+
+use wasmer::{Module, Store};
+
+use crate::atoms;
+
+pub struct ModuleResource {
+    pub module: Mutex<Module>,
+}
+
+#[derive(NifTuple)]
+pub struct ModuleResourceResponse {
+    ok: rustler::Atom,
+    resource: ResourceArc<ModuleResource>,
+}
+
+#[rustler::nif(name = "module_compile")]
+pub fn compile(binary: Binary) -> NifResult<ModuleResourceResponse> {
+    let bytes = binary.as_slice();
+    let store = Store::default();
+    match Module::new(&store, &bytes) {
+        Ok(module) => {
+            let resource = ResourceArc::new(ModuleResource {
+                module: Mutex::new(module),
+            });
+            Ok(ModuleResourceResponse {
+                ok: atoms::ok(),
+                resource,
+            })
+        }
+        Err(e) => Err(rustler::Error::Term(Box::new(format!(
+            "Could not compile module: {:?}",
+            e
+        )))),
+    }
+}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,6 @@
 defmodule TestHelper do
+  @ets_table __MODULE__
+
   @wasm_test_source_dir "#{Path.dirname(__ENV__.file)}/wasm_test"
   @wasm_import_test_source_dir "#{Path.dirname(__ENV__.file)}/wasm_import_test"
   @wasi_test_source_dir "#{Path.dirname(__ENV__.file)}/wasi_test"
@@ -12,11 +14,29 @@ defmodule TestHelper do
   def wasi_test_file_path,
     do: "#{@wasi_test_source_dir}/target/wasm32-wasi/debug/main.wasm"
 
-  def compile_wasm_files do
+  def precompile_wasm_files do
     {"", 0} = System.cmd("cargo", ["build"], cd: @wasm_test_source_dir)
     {"", 0} = System.cmd("cargo", ["build"], cd: @wasm_import_test_source_dir)
     {"", 0} = System.cmd("cargo", ["build"], cd: @wasi_test_source_dir)
+
+    # cache precompiled modules in an ETS so our tests can re-use them
+    :ets.new(@ets_table, [:named_table, read_concurrency: true])
+
+    {:ok, wasm_module} = Wasmex.Module.compile(File.read!(TestHelper.wasm_test_file_path()))
+    :ets.insert(@ets_table, {:wasm, wasm_module})
+
+    {:ok, wasm_import_module} =
+      Wasmex.Module.compile(File.read!(TestHelper.wasm_import_test_file_path()))
+
+    :ets.insert(@ets_table, {:wasm_import, wasm_import_module})
+
+    {:ok, wasi_module} = Wasmex.Module.compile(File.read!(TestHelper.wasi_test_file_path()))
+    :ets.insert(@ets_table, {:wasi, wasi_module})
   end
+
+  def wasm_module, do: :ets.lookup(@ets_table, :wasm) |> Keyword.get(:wasm)
+  def wasm_import_module, do: :ets.lookup(@ets_table, :wasm_import) |> Keyword.get(:wasm_import)
+  def wasi_module, do: :ets.lookup(@ets_table, :wasi) |> Keyword.get(:wasi)
 
   def default_imported_functions_env do
     %{
@@ -33,5 +53,5 @@ defmodule TestHelper do
   end
 end
 
-TestHelper.compile_wasm_files()
+TestHelper.precompile_wasm_files()
 ExUnit.start()

--- a/test/wasmex/memory_test.exs
+++ b/test/wasmex/memory_test.exs
@@ -3,8 +3,8 @@ defmodule Wasmex.MemoryTest do
   doctest Wasmex.Memory
 
   defp build_wasm_instance do
-    bytes = File.read!(TestHelper.wasm_test_file_path())
-    Wasmex.Instance.from_bytes(bytes, %{})
+    TestHelper.wasm_module()
+    |> Wasmex.Instance.new(%{})
   end
 
   defp build_memory(size, offset) do

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -2,11 +2,8 @@ defmodule WasmexTest do
   use ExUnit.Case, async: true
   doctest Wasmex
 
-  @bytes File.read!(TestHelper.wasm_test_file_path())
-  @import_test_bytes File.read!(TestHelper.wasm_import_test_file_path())
-
   defp create_instance(_context) do
-    instance = start_supervised!({Wasmex, %{bytes: @bytes}})
+    instance = start_supervised!({Wasmex, %{module: TestHelper.wasm_module()}})
     %{instance: instance}
   end
 
@@ -131,7 +128,9 @@ defmodule WasmexTest do
         )
     }
 
-    instance = start_supervised!({Wasmex, %{bytes: @import_test_bytes, imports: imports}})
+    instance =
+      start_supervised!({Wasmex, %{module: TestHelper.wasm_import_module(), imports: imports}})
+
     {:ok, memory} = Wasmex.memory(instance, :uint8, 0)
     Wasmex.Memory.set(memory, :uint8, 0, 0, 42)
 
@@ -147,7 +146,9 @@ defmodule WasmexTest do
         env: TestHelper.default_imported_functions_env()
       }
 
-      instance = start_supervised!({Wasmex, %{bytes: @import_test_bytes, imports: imports}})
+      instance =
+        start_supervised!({Wasmex, %{module: TestHelper.wasm_import_module(), imports: imports}})
+
       %{instance: instance}
     end
 
@@ -177,7 +178,9 @@ defmodule WasmexTest do
         "env" => TestHelper.default_imported_functions_env_stringified()
       }
 
-      instance = start_supervised!({Wasmex, %{bytes: @import_test_bytes, imports: imports}})
+      instance =
+        start_supervised!({Wasmex, %{module: TestHelper.wasm_import_module(), imports: imports}})
+
       %{instance: instance}
     end
 
@@ -202,7 +205,9 @@ defmodule WasmexTest do
         }
       }
 
-      instance = start_supervised!({Wasmex, %{bytes: @import_test_bytes, imports: imports}})
+      instance =
+        start_supervised!({Wasmex, %{module: TestHelper.wasm_import_module(), imports: imports}})
+
       %{instance: instance}
     end
 


### PR DESCRIPTION
We used to compile and instantiate modules from .wasm files directly.
This step implicitly compiled a WASM module first, before actually instantiating it.
This PR makes these two steps explicit, by adding `Wasmex.Module.compile/1` and deprecating `Wasmex.Instance.from_bytes/2` and `Wasmex.Instance.wasi_from_bytes/3`.

It is still possible to start the Wasmex GenServer from bytes without deprecation.
But in addition to that, one can now start the GenServer modules from previously compiled modules.
This way, a module can be re-used as often as desired.

This change allows some great speed-ups. E.g. our test suite went from 14.5s runtime down to 0.2s (on my machine).