### PR TITLE
Support WAT and modules without exported memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Types of changes
 
 * `Wasmex.Module.compile/1` which can take the bytes of a .wasm files and compiles the WASM module. This module can be given to the new methods `Wasmex.Instance.new/2` and `Wasmex.Instance.new_wasi/3` allowing to re-used precompiled modules. This has a big potential speed-up if one wishes to run a WASI instance multiple times. For example, the wasmex test suite went from 14.5s to just 0.2s runtime.
 * `Wasmex.start_link` can now also be called with a precompiled module in addition to the .wasm file bytes.
+* `Wasmex.Module.compile/1` can now parse WebAssembly text format (WAT) too
+* WASM modules without exported memory can now be instantiated
 
 ### Deprecated
 

--- a/native/wasmex/src/instance.rs
+++ b/native/wasmex/src/instance.rs
@@ -50,8 +50,10 @@ pub fn new(
             ))))
         }
     };
-    let memory = memory_from_instance(&instance)?.clone();
-    environment.memory.initialize(memory);
+
+    if let Ok(memory) = memory_from_instance(&instance) {
+        environment.memory.initialize(memory.clone());
+    }
 
     let resource = ResourceArc::new(InstanceResource {
         instance: Mutex::new(instance),
@@ -115,8 +117,10 @@ pub fn new_wasi<'a>(
             ))))
         }
     };
-    let memory = memory_from_instance(&instance)?.clone();
-    environment.memory.initialize(memory);
+
+    if let Ok(memory) = memory_from_instance(&instance) {
+        environment.memory.initialize(memory.clone());
+    }
 
     let resource = ResourceArc::new(InstanceResource {
         instance: Mutex::new(instance),

--- a/native/wasmex/src/module.rs
+++ b/native/wasmex/src/module.rs
@@ -1,7 +1,7 @@
 use rustler::{resource::ResourceArc, types::binary::Binary, NifResult};
 use std::sync::Mutex;
 
-use wasmer::{Module, Store};
+use wasmer::{wat2wasm, Module, Store};
 
 use crate::atoms;
 
@@ -18,8 +18,14 @@ pub struct ModuleResourceResponse {
 #[rustler::nif(name = "module_compile")]
 pub fn compile(binary: Binary) -> NifResult<ModuleResourceResponse> {
     let bytes = binary.as_slice();
+    let bytes = wat2wasm(bytes).map_err(|e| {
+        rustler::Error::Term(Box::new(format!(
+            "Error while parsing bytes: {}.",
+            e.to_string()
+        )))
+    })?;
     let store = Store::default();
-    match Module::new(&store, &bytes) {
+    match Module::new(&store, bytes) {
         Ok(module) => {
             let resource = ResourceArc::new(ModuleResource {
                 module: Mutex::new(module),

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -7,6 +7,31 @@ defmodule WasmexTest do
     %{instance: instance}
   end
 
+  describe "module compilation from WAT" do
+    test "instantiates a simple module from wat" do
+      wat = "
+      (module
+        (type $add_one_t (func (param i32) (result i32)))
+        (func $add_one_f (type $add_one_t) (param $value i32) (result i32)
+          local.get $value
+          i32.const 1
+          i32.add)
+        (export \"add_one\" (func $add_one_f)))
+      "
+      {:ok, module} = Wasmex.Module.compile(wat)
+      instance = start_supervised!({Wasmex, %{module: module}})
+      assert {:ok, [42]} == Wasmex.call_function(instance, :add_one, [41])
+    end
+
+    test "errors when attempting to compile nonsense" do
+      wat = "wat is this? not wat for sure"
+
+      assert {:error,
+              "Error while parsing bytes: expected `(`\n     --> <anon>:1:1\n      |\n    1 | wat is this? not wat for sure\n      | ^."} ==
+               Wasmex.Module.compile(wat)
+    end
+  end
+
   describe "when instantiating without imports" do
     setup [:create_instance]
 


### PR DESCRIPTION
* adds support for compiling modules from web assembly text format (WAT)
* removes the constraint of wasm modules needing to export memory

![image](https://user-images.githubusercontent.com/206108/126894571-b96dad5a-4970-42dc-b89a-085905bc6553.png)
