### PR TITLE
Cleanups and version bump to 0.7.0

### DIFF
--- a/.github/workflows/compatibility-elixir.yaml
+++ b/.github/workflows/compatibility-elixir.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         otp: [22.3, 23.3, 24.3]
-        elixir: [1.10.4, 1.11.4, 1.12.3, 1.13.3]
+        elixir: [1.11.4, 1.12.3, 1.13.3]
         exclude:
           - otp: 24.3
             elixir: 1.10.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,19 @@ Types of changes
 
 ## [unreleased changes]
 
+please add changes here
+
+## [0.7.0] - 2022-03-27
+
+### Added
+
+- Added support for precompiled binaries. This should reduce compilation time of wasmex significantly. At the same time it frees most of our users from needing to install Rust. Thanks @fahchen for implementing this feature
+
 ### Changed
 
-- Updated Elixir to 1.13 and OTP to 24.2. Older versions should work, but are not actively tested.
+- Wasmex now aims to support the last three elixir and OTP releases. The oldest supported versions for this release are elixir 1.11.4 and OPT 22.3 - Thanks to @fahchen for contributing the CI workflow to test older elixir/OTP versions
+- Moved CI systems from CircleCI to GitHub Actions. Let me thank CircleCI forthe years of free of charge CI runs, thanks! Let me also thank @fahchen for contributing this change
+- Thanks to @phaleth for fixing page sizes in our Memory documentation
 - Updated several project dependencies, most notably wasmer to 2.1.1
 
 ## [0.6.0] - 2021-08-07

--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ def deps do
 end
 ```
 
-**Note**: [Rust](https://www.rust-lang.org/) is required to install the Elixir library (Cargo — the build tool for Rust — is used to compile the extension).
-See [how to install Rust](https://www.rust-lang.org/tools/install).
-
 The docs can be found at [https://hexdocs.pm/wasmex](https://hexdocs.pm/wasmex/Wasmex.html).
 
 ## Example
@@ -101,6 +98,8 @@ Then install the erlang/elixir dependencies:
 asdf install # assuming you install elixir, erlang with asdf. if not, make sure to install them your way
 mix deps.get
 ```
+
+If you plan to change something on the Rust part of this project, set the following ENV `WASMEX_BUILD=true` so that your changes will be picked up.
 
 I´m looking forward to your contributions. Please open a PR containing the motivation of your change. If it is a bigger change or refactoring, consider creating an issue first. We can discuss changes there first which might safe us time down the road :)
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Wasmex.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.7.0"
 
   def project do
     [

--- a/native/wasmex/Cargo.lock
+++ b/native/wasmex/Cargo.lock
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "wasmex"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "lazy_static",
  "rustler",

--- a/native/wasmex/Cargo.toml
+++ b/native/wasmex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmex"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Philipp Tessenow <philipp@tessenow.org>"]
 description = "Elixir extension to run WebAssembly binaries"
 readme = "README.md"

--- a/test/wasm_import_test/Cargo.toml
+++ b/test/wasm_import_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmex_test"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Philipp Tessenow <philipp@tessenow.org>"]
 edition = "2018"
 

--- a/test/wasm_test/Cargo.toml
+++ b/test/wasm_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmex_test"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Philipp Tessenow <philipp@tessenow.org>"]
 edition = "2018"
 


### PR DESCRIPTION
- require at least elixir 1.11 (we attempt to support the last three elixir releases if possible)
- added changelog entries for the last couple of great contributions
- bump version to 0.7.0

fixes #324 