### PR TITLE
ci: fix release workflow trigger on file-changed and branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,12 +8,13 @@ on:
     branches:
       # Always run on main branch.
       - main
-    paths:
-      # Run if "native" path changed.
-      - 'native/**'
     tags:
       # Tags will always run.
       - '*'
+  pull_request:
+    paths:
+      # Run if "native" path changed.
+      - 'native/**'
 
 defaults:
   run:


### PR DESCRIPTION
> If you define both `branches`/`branches-ignore` and `paths`, the workflow will only run when both filters are satisfied.

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#using-filters-to-target-specific-paths-for-pull-request-or-push-events

For the above reason, the `release` workflow did not run as expected.

related issue: https://github.com/tessi/wasmex/pull/326#issuecomment-1080170610