### PR TITLE
[FEAT] Allow users to configure a timeout value for call_function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Types of changes
 
 please add changes here
 
+- Added an optional fourth parameter to `call_function`, `timeout`, which accepts a value in milliseconds that will cap the execution time of the function. The default behavior if not supplied is preserved, which is a 5 second timeout.
+
 ## [0.7.0] - 2022-03-27
 
 ### Added

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -211,9 +211,15 @@ defmodule Wasmex do
   {:ok, [pointer]} = Wasmex.call_function(instance, "string", [])
   returned_string = Wasmex.Memory.read_string(memory, pointer, 13) # "Hello, World!"
   ```
+
+  #### Specifying a timeout
+  The default timeout for `call_function` is 5 seconds, or 5000 milliseconds. If you're calling a long-running function, you can specify a timeout value (in milliseconds) for this call. Using the above example as a starting point, calling a function with a timeout of 10 seconds looks like:
+  ```elixir
+  {:ok, [pointer]} = Wasmex.call_function(instance, "string", [], 10000)
+  ```
   """
-  def call_function(pid, name, params) do
-    GenServer.call(pid, {:call_function, stringify(name), params})
+  def call_function(pid, name, params, timeout \\ 5000) do
+    GenServer.call(pid, {:call_function, stringify(name), params}, timeout)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Wasmex.MixProject do
   use Mix.Project
 
-  @version "0.7.1"
+  @version "0.7.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Wasmex.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.7.1"
 
   def project do
     [


### PR DESCRIPTION
Fixes #332 

Hi! 👋🏻 We use Wasmex as the underlying Wasm wrapper for https://github.com/wasmCloud/wasmcloud-otp, and we allow users to configure a timeout for calling a Wasm function. In the interest of supporting that use case, I wanted to allow the `call_function` function to accept a timeout value.

I've kept the default value the same as https://hexdocs.pm/elixir/1.13/GenServer.html#call/3, with the same style of using a default value if the parameter isn't supplied. I also bumped a patch version, but please let me know if this doesn't conform to your semver strategy and I can remove that.