### PR TITLE
Improve build/release toolchain

### DIFF
--- a/.github/workflows/compatibility-elixir.yaml
+++ b/.github/workflows/compatibility-elixir.yaml
@@ -29,7 +29,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
 
-      - uses: dtolnay/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           override: true

--- a/.github/workflows/compatibility-elixir.yaml
+++ b/.github/workflows/compatibility-elixir.yaml
@@ -29,7 +29,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/toolchain@v1
         with:
           toolchain: stable
           override: true

--- a/.github/workflows/elixir-ci.yaml
+++ b/.github/workflows/elixir-ci.yaml
@@ -31,7 +31,7 @@ jobs:
           default: true
 
       - id: get-cache-key
-        run: echo "::set-output name=key::mix-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ hashFiles('**/mix.lock') }}"
+        run: echo "key=mix-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ hashFiles('**/mix.lock') }}"
 
       - uses: actions/cache@v2
         id: cache-deps

--- a/.github/workflows/elixir-ci.yaml
+++ b/.github/workflows/elixir-ci.yaml
@@ -24,7 +24,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/toolchain@v1
         with:
           toolchain: stable
           override: true
@@ -143,7 +143,7 @@ jobs:
             _build
           key: ${{ needs.deps.outputs.deps-cache-key }}
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/toolchain@v1
         with:
           toolchain: stable
           override: true

--- a/.github/workflows/elixir-ci.yaml
+++ b/.github/workflows/elixir-ci.yaml
@@ -24,7 +24,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
 
-      - uses: dtolnay/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           override: true
@@ -143,7 +143,7 @@ jobs:
             _build
           key: ${{ needs.deps.outputs.deps-cache-key }}
 
-      - uses: dtolnay/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           override: true

--- a/.github/workflows/elixir-ci.yaml
+++ b/.github/workflows/elixir-ci.yaml
@@ -31,7 +31,7 @@ jobs:
           default: true
 
       - id: get-cache-key
-        run: echo "key=mix-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ hashFiles('**/mix.lock') }}"
+        run: echo "key=mix-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ hashFiles('**/mix.lock') }}" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v2
         id: cache-deps

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,8 +146,8 @@ jobs:
         LIB_FINAL_PATH="${NIF_DIRECTORY}/${LIB_FINAL_NAME}.tar.gz"
 
         # Let subsequent steps know where to find the lib
-        echo ::set-output name=LIB_FINAL_PATH::${LIB_FINAL_PATH}
-        echo ::set-output name=LIB_FINAL_NAME::${LIB_FINAL_NAME}.tar.gz
+        echo LIB_FINAL_PATH=${LIB_FINAL_PATH}
+        echo LIB_FINAL_NAME=${LIB_FINAL_NAME}.tar.gz
 
     - name: "Artifact upload"
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,8 +87,8 @@ jobs:
       if: ${{ matrix.job.use-cross }}
       with:
         binary: "cross"
-        version: "v0.2.1"
-        download_url: "https://github.com/rust-embedded/cross/releases/download/${version}/cross-${version}-x86_64-unknown-linux-gnu.tar.gz"
+        version: "v0.2.2"
+        download_url: "https://github.com/cross-rs/cross/releases/download/${version}/cross-x86_64-unknown-linux-gnu.tar.gz"
         tarball_binary_path: "${binary}"
         smoke_test: "${binary} --version"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,8 +146,8 @@ jobs:
         LIB_FINAL_PATH="${NIF_DIRECTORY}/${LIB_FINAL_NAME}.tar.gz"
 
         # Let subsequent steps know where to find the lib
-        echo "LIB_FINAL_PATH=${ LIB_FINAL_PATH }" >> $GITHUB_OUTPUT
-        echo "LIB_FINAL_NAME=${ LIB_FINAL_NAME }.tar.gz" >> $GITHUB_OUTPUT
+        echo "LIB_FINAL_PATH=${{ LIB_FINAL_PATH }}" >> $GITHUB_OUTPUT
+        echo "LIB_FINAL_NAME=${{ LIB_FINAL_NAME }}.tar.gz" >> $GITHUB_OUTPUT
 
     - name: "Artifact upload"
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,8 +146,8 @@ jobs:
         LIB_FINAL_PATH="${NIF_DIRECTORY}/${LIB_FINAL_NAME}.tar.gz"
 
         # Let subsequent steps know where to find the lib
-        echo LIB_FINAL_PATH=${LIB_FINAL_PATH}
-        echo LIB_FINAL_NAME=${LIB_FINAL_NAME}.tar.gz
+        echo "LIB_FINAL_PATH=${ LIB_FINAL_PATH }" >> $GITHUB_OUTPUT
+        echo "LIB_FINAL_NAME=${ LIB_FINAL_NAME }.tar.gz" >> $GITHUB_OUTPUT
 
     - name: "Artifact upload"
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
           # cranelift-codegen panics at 'error when identifying target: "no supported isa found for arch `arm`"'
           # - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , use-cross: true }
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-20.04 , use-cross: true }
           - { target: aarch64-apple-darwin        , os: macos-11      }
           - { target: x86_64-apple-darwin         , os: macos-11      }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04  }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
         echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' ../../mix.exs | head -n1)" >> $GITHUB_ENV
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/toolchain@v1
       with:
         toolchain: stable
         target: ${{ matrix.job.target }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
         echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' ../../mix.exs | head -n1)" >> $GITHUB_ENV
 
     - name: Install Rust toolchain
-      uses: dtolnay/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
         target: ${{ matrix.job.target }}

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           override: true

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/toolchain@v1
         with:
           toolchain: stable
           override: true

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ wapm.lock
 # The PLT files for `dialyzer`
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
+
+/checksum-Elixir.Wasmex.Native.exs
+/priv/native
+/priv/plts

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,3 @@ wapm.lock
 # The PLT files for `dialyzer`
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
-
-/checksum-Elixir.Wasmex.Native.exs
-/priv/native
-/priv/plts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,16 @@ Types of changes
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [unreleased changes]
+## [0.8.1] - unreleased
 
-please add changes here
+### Added
+
+* Added precompiled binary for `aarch64-unknown-linux-musl`
+
+### Changed
+
+* `mix.exs` now also requires at least Elixir 1.12
+
 ## [0.8.0] - 2023-01-03
 
 This release brings some changes to our API because of the change of the underlying WASM engine to [wasmtime](https://wasmtime.dev/).

--- a/README.md
+++ b/README.md
@@ -106,6 +106,25 @@ In addition to tests, we expect the formatters and linters (`cargo fmt`, `cargo 
 
 Your contributions will be licenced under the same license as this project.
 
+### Release
+
+To release this package, make sure CI is green, increase the package version, and:
+
+```
+git tag -a v0.8.0 # change version accordingly, copy changelog into tag message
+git push --tags
+mix rustler_precompiled.download Wasmex.Native --all --ignore-unavailable --print
+```
+
+Inspect it's output carefully, but ignore NIF version `2.14` and `arm-unknown-linux-gnueabihf` arch errors because we don't build for them.
+Now inspect the checksum-Elixir.Wasmex.Native.exs file - it should include all prebuilt binaries in their checksums
+
+Then continue with
+
+```
+mix hex.publish
+```
+
 ## License
 
 The entire project is under the MIT License. Please read [the`LICENSE` file](https://github.com/tessi/wasmex/blob/master/LICENSE).

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,13 @@
 defmodule Wasmex.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.8.1-dev"
 
   def project do
     [
       app: :wasmex,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       name: "wasmex",
       description: description(),

--- a/native/wasmex/.cargo/config
+++ b/native/wasmex/.cargo/config
@@ -10,6 +10,11 @@ rustflags = [
   "-C", "target-feature=-crt-static"
 ]
 
+[target.aarch64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
+]
+
 # Provides a small build size, but takes more time to build.
 [profile.release]
 lto = true

--- a/native/wasmex/.cargo/config
+++ b/native/wasmex/.cargo/config
@@ -1,14 +1,8 @@
-[target.x86_64-apple-darwin]
+[target.'cfg(target_os = "macos")']
 rustflags = [
-    "-C", "link-arg=-undefined",
-    "-C", "link-arg=dynamic_lookup",
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
 ]
-
-[target.aarch64-apple-darwin]
- rustflags = [
-     "-C", "link-arg=-undefined",
-     "-C", "link-arg=dynamic_lookup",
- ]
 
 # See https://github.com/rust-lang/rust/issues/59302
 [target.x86_64-unknown-linux-musl]

--- a/native/wasmex/Cross.toml
+++ b/native/wasmex/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+  "RUSTLER_NIF_VERSION"
+]


### PR DESCRIPTION
While building the 0.8.0 release I noticed some warning in our CI actions and build toolchain. This MR attempts to fix them -- all fixed in one MR and not on `main` because we all know CI needs several attempts to get right :)