### PR TITLE
Add support for setting Store limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Types of changes
 ### Added
 
 * Added precompiled binary for `aarch64-unknown-linux-musl`
+* Added support for setting store limits. This allows users to limit memory usage, instance creation, table sizes and more. See `Wasmex.StoreLimits` for details.
 
 ### Changed
 

--- a/lib/wasmex/native.ex
+++ b/lib/wasmex/native.ex
@@ -52,8 +52,8 @@ defmodule Wasmex.Native do
   def pipe_read_binary(_pipe_resource), do: error()
   def pipe_write_binary(_pipe_resource, _binary), do: error()
 
-  def store_new(), do: error()
-  def store_new_wasi(_opts), do: error()
+  def store_new(_store_limits), do: error()
+  def store_new_wasi(_wasi_options, _store_limits), do: error()
 
   # When the NIF is loaded, it will override functions in this module.
   # Calling error is handles the case when the nif could not be loaded.

--- a/lib/wasmex/store_limits.ex
+++ b/lib/wasmex/store_limits.ex
@@ -1,0 +1,36 @@
+defmodule Wasmex.StoreLimits do
+  @moduledoc ~S"""
+  Configures limits to limit resource creation within a `Wasmex.Store`.
+
+  Whenever resources such as linear memory, tables, or instances are
+  allocated the `StoreLimits` specified here are enforced.
+
+  ## Options
+
+    * `:memory_size` - The maximum number of bytes a linear memory can grow to. Growing a linear memory beyond this limit will fail. By default, linear memory will not be limited.
+    * `:table_elements` - The maximum number of elements in a table. Growing a table beyond this limit will fail. By default, table elements will not be limited.
+    * `:instances` - The maximum number of instances that can be created for a `Wasmex.Store`. Module instantiation will fail if this limit is exceeded. This value defaults to 10,000.
+    * `:tables` - The maximum number of tables that can be created for a `Wasmex.Store`. Module instantiation will fail if this limit is exceeded. This value defaults to 10,000.
+    * `:memories` - The maximum number of linear memories that can be created for a `Wasmex.Store`. Instantiation will fail with an error if this limit is exceeded. This value defaults to 10,000.
+
+  ## Example
+
+      iex> Wasmex.Store.new(%Wasmex.StoreLimits{
+      ...>   memory_size: 1_000_000,
+      ...>   table_elements: 100_000,
+      ...>   instances: 2,
+      ...>   tables: 10
+      ...>   memories: 10
+      ...> })
+  """
+
+  defstruct [:memory_size, :table_elements, :instances, :tables, :memories]
+
+  @type t :: %__MODULE__{
+          memory_size: non_neg_integer() | nil,
+          table_elements: non_neg_integer() | nil,
+          instances: non_neg_integer() | nil,
+          tables: non_neg_integer() | nil,
+          memories: non_neg_integer() | nil
+        }
+end

--- a/native/wasmex/Cargo.lock
+++ b/native/wasmex/Cargo.lock
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "wasmex"
-version = "0.1.0"
+version = "0.8.1-dev"
 dependencies = [
  "once_cell",
  "rand",

--- a/native/wasmex/Cargo.toml
+++ b/native/wasmex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmex"
-version = "0.1.0"
+version = "0.8.1-dev"
 authors = ["Philipp Tessenow <philipp@tessenow.org>"]
 description = "Elixir extension to run WebAssembly binaries through wasmtime"
 readme = "README.md"

--- a/native/wasmex/src/store.rs
+++ b/native/wasmex/src/store.rs
@@ -1,3 +1,8 @@
+// Due to a clippy bug it thinks we needlessly borrow stuff
+// when defining the ExStoreLimits struct
+// see: https://github.com/rust-lang/rust-clippy/issues/9778
+#![allow(clippy::needless_borrow)]
+
 use rustler::{resource::ResourceArc, Error, NifResult};
 use std::{collections::HashMap, sync::Mutex};
 use wasi_common::WasiCtx;
@@ -27,22 +32,22 @@ pub struct ExPipe {
 #[module = "Wasmex.Wasi.WasiOptions"]
 #[rustler(decode)]
 pub struct ExWasiOptions {
-    pub(crate) args: Vec<String>,
-    pub(crate) env: HashMap<String, String>,
-    pub(crate) stderr: Option<ExPipe>,
-    pub(crate) stdin: Option<ExPipe>,
-    pub(crate) stdout: Option<ExPipe>,
-    pub(crate) preopen: Vec<ExWasiPreopenOptions>,
+    args: Vec<String>,
+    env: HashMap<String, String>,
+    stderr: Option<ExPipe>,
+    stdin: Option<ExPipe>,
+    stdout: Option<ExPipe>,
+    preopen: Vec<ExWasiPreopenOptions>,
 }
 
 #[derive(NifStruct)]
 #[module = "Wasmex.StoreLimits"]
 pub struct ExStoreLimits {
-    pub(crate) memory_size: Option<usize>,
-    pub(crate) table_elements: Option<u32>,
-    pub(crate) instances: Option<usize>,
-    pub(crate) tables: Option<usize>,
-    pub(crate) memories: Option<usize>,
+    memory_size: Option<usize>,
+    table_elements: Option<u32>,
+    instances: Option<usize>,
+    tables: Option<usize>,
+    memories: Option<usize>,
 }
 
 impl ExStoreLimits {

--- a/test/wasmex/store_test.exs
+++ b/test/wasmex/store_test.exs
@@ -10,6 +10,31 @@ defmodule Wasmex.StoreTest do
     end
   end
 
+  describe t(&Store.new/1) do
+    test "creates a new Store with limits lower than the default 17 pages" do
+      limits = %Wasmex.StoreLimits{memory_size: 1_000}
+      assert {:ok, store} = Wasmex.Store.new(limits)
+      {:ok, module} = Wasmex.Module.compile(store, File.read!(TestHelper.wasm_test_file_path()))
+
+      {:error, "memory minimum size of 17 pages exceeds memory limits"} =
+        Wasmex.Instance.new(store, module, %{})
+    end
+
+    test "creates a new Store with limits at exactly the default 17 pages" do
+      page_size = 64 * 1024
+      limits = %Wasmex.StoreLimits{memory_size: page_size * 17}
+      assert {:ok, store} = Wasmex.Store.new(limits)
+      {:ok, module} = Wasmex.Module.compile(store, File.read!(TestHelper.wasm_test_file_path()))
+      {:ok, instance} = Wasmex.Instance.new(store, module, %{})
+
+      # The memory is 17 pages by default, so we can't grow it by 1 page
+      {:ok, memory} = Wasmex.Instance.memory(store, instance)
+
+      assert {:error, "Failed to grow the memory: failed to grow memory by `1`."} =
+               Wasmex.Memory.grow(store, memory, 1)
+    end
+  end
+
   describe t(&Store.new_wasi/1) do
     test "creates a new Store with Wasi Options" do
       assert {:ok, %Wasmex.StoreOrCaller{}} =


### PR DESCRIPTION
This allows users to limit resource usage (memory, table size, instance count) for Wasmex.Store. See Wasmex.StoreLimits for details.

Whenever resources such as linear memory, tables, or instances are allocated the `StoreLimits` are enforced.