### PR TITLE
Add option to EngineConfig to configure cranelift_opt_level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Today, a `Wasmex.Engine` already gives us a faster way to precompile modules wit
 * Added `Wasmex.EngineConfig` as a place for more complex WASM settings. With this release an engine can be configured to provide more detailed backtraces on errors during WASM execution by setting the `wasm_backtrace_details` flag.
 * Added `Wasmex.Engine.precompile_module/2` which allows module precompilation from a .wat or .wasm binary without the need to instantiate said module. A precompiled module can be hydrated with `Module.unsafe_deserialize/2`.
 * Added `Wasmex.module/1` and `Wasmex.store/1` to access the module and store of a running Wasmex GenServer process.
+* Added option to `Wasmex.EngineConfig` to configure the `cranelift_opt_level` (:none, :speed, :speed_and_size) allowing users to trade compilation time against execution speed
 
 ### Changed
 

--- a/lib/wasmex/engine_config.ex
+++ b/lib/wasmex/engine_config.ex
@@ -5,20 +5,24 @@ defmodule Wasmex.EngineConfig do
   ## Options
 
     * `:consume_fuel` - Whether or not to consume fuel when executing WASM instructions. This defaults to `false`.
+    * `:cranelift_opt_level` - Optimization level for the Cranelift code generator. This defaults to `:none`.
     * `:wasm_backtrace_details` - Whether or not backtraces in traps will parse debug info in the WASM file to have filename/line number information. This defaults to `false`.
 
   ## Example
 
       iex> _config = %Wasmex.EngineConfig{}
       ...>           |> Wasmex.EngineConfig.consume_fuel(true)
+      ...>           |> Wasmex.EngineConfig.cranelift_opt_level(:speed)
       ...>           |> Wasmex.EngineConfig.wasm_backtrace_details(false)
   """
 
   defstruct consume_fuel: false,
+            cranelift_opt_level: :none,
             wasm_backtrace_details: false
 
   @type t :: %__MODULE__{
           consume_fuel: boolean(),
+          cranelift_opt_level: :none | :speed | :speed_and_size,
           wasm_backtrace_details: boolean()
         }
 
@@ -44,6 +48,21 @@ defmodule Wasmex.EngineConfig do
   @spec consume_fuel(t(), boolean()) :: t()
   def consume_fuel(%__MODULE__{} = config, consume_fuel) do
     %__MODULE__{config | consume_fuel: consume_fuel}
+  end
+
+  @doc """
+  Configures the Cranelift code generator optimization level.
+
+  Allows one of the following values:
+
+  * `:none` - No optimizations performed, minimizes compilation time by disabling most optimizations.
+  * `:speed` - Generates the fastest possible code, but may take longer.
+  * `:speed_and_size` - Similar to `speed`, but also performs transformations aimed at reducing code size.
+  """
+  @spec cranelift_opt_level(t(), :none | :speed | :speed_and_size) :: t()
+  def cranelift_opt_level(%__MODULE__{} = config, cranelift_opt_level)
+      when cranelift_opt_level in [:none, :speed, :speed_and_size] do
+    %__MODULE__{config | cranelift_opt_level: cranelift_opt_level}
   end
 
   @doc ~S"""

--- a/native/wasmex/src/atoms.rs
+++ b/native/wasmex/src/atoms.rs
@@ -40,4 +40,9 @@ rustler::atoms! {
     // calls to erlang processes
     returned_function_call,
     invoke_callback,
+
+    // engine config - cranelift_opt_level
+    none,
+    speed,
+    speed_and_size,
 }

--- a/test/wasmex/engine_config_test.exs
+++ b/test/wasmex/engine_config_test.exs
@@ -18,7 +18,9 @@ defmodule Wasmex.EngineConfigTest do
       config = %EngineConfig{}
       assert %{cranelift_opt_level: :none} = EngineConfig.cranelift_opt_level(config, :none)
       assert %{cranelift_opt_level: :speed} = EngineConfig.cranelift_opt_level(config, :speed)
-      assert %{cranelift_opt_level: :speed_and_size} = EngineConfig.cranelift_opt_level(config, :speed_and_size)
+
+      assert %{cranelift_opt_level: :speed_and_size} =
+               EngineConfig.cranelift_opt_level(config, :speed_and_size)
     end
   end
 

--- a/test/wasmex/engine_config_test.exs
+++ b/test/wasmex/engine_config_test.exs
@@ -13,6 +13,15 @@ defmodule Wasmex.EngineConfigTest do
     end
   end
 
+  describe t(&EngineConfig.cranelift_opt_level/1) do
+    test "sets the cranelift_opt_level option" do
+      config = %EngineConfig{}
+      assert %{cranelift_opt_level: :none} = EngineConfig.cranelift_opt_level(config, :none)
+      assert %{cranelift_opt_level: :speed} = EngineConfig.cranelift_opt_level(config, :speed)
+      assert %{cranelift_opt_level: :speed_and_size} = EngineConfig.cranelift_opt_level(config, :speed_and_size)
+    end
+  end
+
   describe t(&EngineConfig.wasm_backtrace_details/1) do
     test "sets the wasm_backtrace_details option" do
       config = %EngineConfig{}

--- a/test/wasmex/engine_test.exs
+++ b/test/wasmex/engine_test.exs
@@ -2,32 +2,44 @@ defmodule Wasmex.EngineTest do
   use ExUnit.Case, async: true
   import TestHelper, only: [t: 1]
 
-  doctest Wasmex.Engine
+  alias Wasmex.Engine
+  alias Wasmex.EngineConfig
+  alias Wasmex.Module
+
+  doctest Engine
 
   describe t(&Engine.new/1) do
     test "creates a new Engine" do
-      assert {:ok, %Wasmex.Engine{}} = Wasmex.Engine.new(%Wasmex.EngineConfig{})
+      assert {:ok, %Engine{}} = Engine.new(%EngineConfig{})
     end
   end
 
   describe t(&Engine.default/1) do
     test "creates an Engine with default config" do
-      assert %Wasmex.Engine{} = Wasmex.Engine.default()
+      assert %Engine{} = Engine.default()
+    end
+
+    test "creates an Engine with a changed config" do
+      assert {:ok, %Engine{}} =
+               %EngineConfig{}
+               |> EngineConfig.consume_fuel(true)
+               |> EngineConfig.cranelift_opt_level(:speed)
+               |> Engine.new()
     end
   end
 
   describe t(&Engine.precompile/2) do
     test "precompiles a module" do
-      {:ok, engine} = Wasmex.Engine.new(%Wasmex.EngineConfig{})
+      {:ok, engine} = Engine.new(%EngineConfig{})
       wasm_bytes = File.read!(TestHelper.wasm_test_file_path())
 
-      assert {:ok, serialized_module} = Wasmex.Engine.precompile_module(engine, wasm_bytes)
+      assert {:ok, serialized_module} = Engine.precompile_module(engine, wasm_bytes)
       assert is_binary(serialized_module)
 
-      {:ok, deserialized_module} = Wasmex.Module.unsafe_deserialize(serialized_module)
+      {:ok, deserialized_module} = Module.unsafe_deserialize(serialized_module)
       %{module: module} = TestHelper.wasm_module()
 
-      assert Wasmex.Module.exports(module) == Wasmex.Module.exports(deserialized_module)
+      assert Module.exports(module) == Module.exports(deserialized_module)
     end
   end
 end


### PR DESCRIPTION
It configures the Cranelift code generator optimization level.

Allows one of the following values:

  * `:none` - No optimizations performed, minimizes compilation time by disabling most optimizations.
  * `:speed` - Generates the fastest possible code, but may take longer.
  * `:speed_and_size` - Similar to `speed`, but also performs transformations aimed at reducing code size.