### PR TITLE
Improve tests reliability

### DIFF
--- a/native/wasmex/src/engine.rs
+++ b/native/wasmex/src/engine.rs
@@ -38,11 +38,11 @@ pub fn precompile_module<'a>(
     binary: Binary<'a>,
 ) -> Result<Binary<'a>, rustler::Error> {
     let engine: &Engine = &*(engine_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock engine resource: {}", e)))
+        rustler::Error::Term(Box::new(format!("Could not unlock engine resource: {e}")))
     })?);
     let bytes = binary.as_slice();
     let serialized_module = engine.precompile_module(bytes).map_err(|err| {
-        rustler::Error::Term(Box::new(format!("Could not precompile module: {}", err)))
+        rustler::Error::Term(Box::new(format!("Could not precompile module: {err}")))
     })?;
     let mut binary = OwnedBinary::new(serialized_module.len())
         .ok_or_else(|| rustler::Error::Term(Box::new("not enough memory")))?;
@@ -78,8 +78,7 @@ pub(crate) fn unwrap_engine(
         .lock()
         .map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock engine resource as the mutex was poisoned: {}",
-                e
+                "Could not unlock engine resource as the mutex was poisoned: {e}"
             )))
         })?
         .clone();

--- a/native/wasmex/src/instance.rs
+++ b/native/wasmex/src/instance.rs
@@ -39,15 +39,13 @@ pub fn new(
 ) -> Result<ResourceArc<InstanceResource>, rustler::Error> {
     let module = module_resource.inner.lock().map_err(|e| {
         rustler::Error::Term(Box::new(format!(
-            "Could not unlock module resource as the mutex was poisoned: {}",
-            e
+            "Could not unlock module resource as the mutex was poisoned: {e}"
         )))
     })?;
     let store_or_caller: &mut StoreOrCaller =
         &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource as the mutex was poisoned: {}",
-                e
+                "Could not unlock store_or_caller resource as the mutex was poisoned: {e}"
             )))
         })?);
 
@@ -83,15 +81,13 @@ pub fn function_export_exists(
 ) -> NifResult<bool> {
     let instance: Instance = *(instance_resource.inner.lock().map_err(|e| {
         rustler::Error::Term(Box::new(format!(
-            "Could not unlock instance resource as the mutex was poisoned: {}",
-            e
+            "Could not unlock instance resource as the mutex was poisoned: {e}"
         )))
     })?);
     let store_or_caller: &mut StoreOrCaller =
         &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock instance/store resource as the mutex was poisoned: {}",
-                e
+                "Could not unlock instance/store resource as the mutex was poisoned: {e}"
             )))
         })?);
 
@@ -100,8 +96,8 @@ pub fn function_export_exists(
 }
 
 #[rustler::nif(name = "instance_call_exported_function", schedule = "DirtyCpu")]
-pub fn call_exported_function<'a>(
-    env: rustler::Env<'a>,
+pub fn call_exported_function(
+    env: rustler::Env,
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     instance_resource: ResourceArc<InstanceResource>,
     function_name: String,
@@ -155,7 +151,7 @@ fn execute_function(
         None => {
             return make_error_tuple(
                 &thread_env,
-                &format!("exported function `{}` not found", function_name),
+                &format!("exported function `{function_name}` not found"),
                 from,
             )
         }
@@ -181,7 +177,7 @@ fn execute_function(
     match call_result {
         Ok(_) => (),
         Err(err) => {
-            let reason = format!("Error during function excecution: `{}`.", err);
+            let reason = format!("Error during function excecution: `{err}`.");
             return make_error_tuple(&thread_env, &reason, from);
         }
     };
@@ -346,8 +342,7 @@ pub fn receive_callback_result(
             Ok(v) => v,
             Err(reason) => {
                 return Err(Error::Term(Box::new(format!(
-                    "could not convert callback result param to expected return signature: {}",
-                    reason
+                    "could not convert callback result param to expected return signature: {reason}"
                 ))));
             }
         }

--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -21,16 +21,12 @@ pub fn from_instance(
     instance_resource: ResourceArc<instance::InstanceResource>,
 ) -> Result<ResourceArc<MemoryResource>, rustler::Error> {
     let instance: Instance = *(instance_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!(
-            "Could not unlock instance resource: {}",
-            e
-        )))
+        rustler::Error::Term(Box::new(format!("Could not unlock instance resource: {e}")))
     })?);
     let store_or_caller: &mut StoreOrCaller =
         &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource: {}",
-                e
+                "Could not unlock store_or_caller resource: {e}"
             )))
         })?);
     let memory = memory_from_instance(&instance, store_or_caller)?;
@@ -48,10 +44,10 @@ pub fn size(
 ) -> NifResult<usize> {
     let store_or_caller: &StoreOrCaller =
         &*(store_or_caller_resource.inner.try_lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {}", e)))
+            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
         })?);
     let memory = memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {}", e)))
+        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
     })?;
     let length = memory.data_size(store_or_caller);
     Ok(length)
@@ -66,12 +62,11 @@ pub fn grow(
     let store_or_caller: &mut StoreOrCaller =
         &mut *(store_or_caller_resource.inner.try_lock().map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource: {}",
-                e
+                "Could not unlock store_or_caller resource: {e}"
             )))
         })?);
     let memory = memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {}", e)))
+        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
     })?;
     let store = match store_or_caller {
         StoreOrCaller::Store(store) => store,
@@ -91,7 +86,7 @@ fn grow_by_pages<T>(
 ) -> Result<u64, Error> {
     memory
         .grow(store, number_of_pages)
-        .map_err(|err| Error::Term(Box::new(format!("Failed to grow the memory: {}.", err))))
+        .map_err(|err| Error::Term(Box::new(format!("Failed to grow the memory: {err}."))))
 }
 
 #[rustler::nif(name = "memory_get_byte")]
@@ -101,10 +96,10 @@ pub fn get_byte(
     index: usize,
 ) -> NifResult<u8> {
     let store_or_caller = &*(store_or_caller_resource.inner.try_lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock store resource: {}", e)))
+        rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
     })?);
     let memory: &Memory = &*(memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {}", e)))
+        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
     })?);
 
     let mut buffer = [0];
@@ -123,10 +118,10 @@ pub fn set_byte(
     value: Term,
 ) -> NifResult<Atom> {
     let store_or_caller = &mut *(store_or_caller_resource.inner.try_lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock store resource: {}", e)))
+        rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
     })?);
     let memory: &Memory = &*(memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {}", e)))
+        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
     })?);
     let value = value.decode()?;
     memory
@@ -157,12 +152,11 @@ pub fn read_binary(
     let store_or_caller: &StoreOrCaller =
         &*(store_or_caller_resource.inner.try_lock().map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource: {}",
-                e
+                "Could not unlock store_or_caller resource: {e}"
             )))
         })?);
     let memory: &Memory = &*(memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {}", e)))
+        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
     })?);
     let mut buffer = vec![0u8; len];
 
@@ -186,12 +180,11 @@ pub fn write_binary(
     let store_or_caller: &mut StoreOrCaller =
         &mut *(store_or_caller_resource.inner.try_lock().map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource: {}",
-                e
+                "Could not unlock store_or_caller resource: {e}"
             )))
         })?);
     let memory: &Memory = &*(memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {}", e)))
+        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
     })?);
     memory
         .write(store_or_caller, index, binary.as_slice())

--- a/native/wasmex/src/module.rs
+++ b/native/wasmex/src/module.rs
@@ -27,14 +27,12 @@ pub fn compile(
     let store_or_caller: &mut StoreOrCaller =
         &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource as the mutex was poisoned: {}",
-                e
+                "Could not unlock store_or_caller resource as the mutex was poisoned: {e}"
             )))
         })?);
     let bytes = binary.as_slice();
-    let bytes = wat::parse_bytes(bytes).map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Error while parsing bytes: {}.", e)))
-    })?;
+    let bytes = wat::parse_bytes(bytes)
+        .map_err(|e| rustler::Error::Term(Box::new(format!("Error while parsing bytes: {e}."))))?;
     match Module::new(store_or_caller.engine(), bytes) {
         Ok(module) => {
             let resource = ResourceArc::new(ModuleResource {
@@ -43,8 +41,7 @@ pub fn compile(
             Ok(resource)
         }
         Err(e) => Err(rustler::Error::Term(Box::new(format!(
-            "Could not compile module: {:?}",
-            e
+            "Could not compile module: {e:?}"
         )))),
     }
 }
@@ -53,8 +50,7 @@ pub fn compile(
 pub fn name(module_resource: ResourceArc<ModuleResource>) -> NifResult<String> {
     let module = module_resource.inner.lock().map_err(|e| {
         rustler::Error::Term(Box::new(format!(
-            "Could not unlock module resource as the mutex was poisoned: {}",
-            e
+            "Could not unlock module resource as the mutex was poisoned: {e}"
         )))
     })?;
     let name = module
@@ -67,8 +63,7 @@ pub fn name(module_resource: ResourceArc<ModuleResource>) -> NifResult<String> {
 pub fn exports(env: rustler::Env, module_resource: ResourceArc<ModuleResource>) -> NifResult<Term> {
     let module = module_resource.inner.lock().map_err(|e| {
         rustler::Error::Term(Box::new(format!(
-            "Could not unlock module resource as the mutex was poisoned: {}",
-            e
+            "Could not unlock module resource as the mutex was poisoned: {e}"
         )))
     })?;
     let mut map = rustler::Term::map_new(env);
@@ -89,8 +84,7 @@ pub fn exports(env: rustler::Env, module_resource: ResourceArc<ModuleResource>) 
 pub fn imports(env: rustler::Env, module_resource: ResourceArc<ModuleResource>) -> NifResult<Term> {
     let module = module_resource.inner.lock().map_err(|e| {
         rustler::Error::Term(Box::new(format!(
-            "Could not unlock module resource as the mutex was poisoned: {}",
-            e
+            "Could not unlock module resource as the mutex was poisoned: {e}"
         )))
     })?;
     let mut namespaces = HashMap::new();
@@ -238,13 +232,12 @@ pub fn serialize(
 ) -> NifResult<Binary> {
     let module = module_resource.inner.lock().map_err(|e| {
         rustler::Error::Term(Box::new(format!(
-            "Could not unlock module resource as the mutex was poisoned: {}",
-            e
+            "Could not unlock module resource as the mutex was poisoned: {e}"
         )))
     })?;
-    let serialized_module: Vec<u8> = module.serialize().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not serialize module: {}", e)))
-    })?;
+    let serialized_module: Vec<u8> = module
+        .serialize()
+        .map_err(|e| rustler::Error::Term(Box::new(format!("Could not serialize module: {e}"))))?;
     let mut binary = OwnedBinary::new(serialized_module.len())
         .ok_or_else(|| rustler::Error::Term(Box::new("not enough memory")))?;
     binary.copy_from_slice(&serialized_module);
@@ -264,7 +257,7 @@ pub fn unsafe_deserialize(
     // However, there isn't much we can do about it here, we will warn users in elixir-land about this, though.
     let module = unsafe {
         Module::deserialize(&engine, binary.as_slice()).map_err(|e| {
-            rustler::Error::Term(Box::new(format!("Could not deserialize module: {}", e)))
+            rustler::Error::Term(Box::new(format!("Could not deserialize module: {e}")))
         })?
     };
     let resource = ResourceArc::new(ModuleResource {

--- a/native/wasmex/src/store.rs
+++ b/native/wasmex/src/store.rs
@@ -214,7 +214,7 @@ pub fn fuel_consumed(
 ) -> Result<Option<u64>, rustler::Error> {
     let store_or_caller: &StoreOrCaller =
         &*(store_or_caller_resource.inner.try_lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {}", e)))
+            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
         })?);
     match store_or_caller {
         StoreOrCaller::Store(store) => Ok(store.fuel_consumed()),
@@ -235,7 +235,7 @@ pub fn add_fuel(
 ) -> Result<(), rustler::Error> {
     let store_or_caller: &mut StoreOrCaller =
         &mut *(store_or_caller_resource.inner.try_lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {}", e)))
+            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
         })?);
     match store_or_caller {
         StoreOrCaller::Store(store) => store.add_fuel(fuel),
@@ -247,7 +247,7 @@ pub fn add_fuel(
             })
             .map(|c| c.add_fuel(fuel))?,
     }
-    .map_err(|e| rustler::Error::Term(Box::new(format!("Could not add fuel to store: {}", e))))
+    .map_err(|e| rustler::Error::Term(Box::new(format!("Could not add fuel to store: {e}"))))
 }
 
 #[rustler::nif(name = "store_or_caller_consume_fuel")]
@@ -257,7 +257,7 @@ pub fn consume_fuel(
 ) -> Result<u64, rustler::Error> {
     let store_or_caller: &mut StoreOrCaller =
         &mut *(store_or_caller_resource.inner.try_lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {}", e)))
+            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
         })?);
     match store_or_caller {
         StoreOrCaller::Store(store) => store.consume_fuel(fuel),
@@ -269,7 +269,7 @@ pub fn consume_fuel(
             })
             .map(|c| c.consume_fuel(fuel))?,
     }
-    .map_err(|e| rustler::Error::Term(Box::new(format!("Could not consume fuel: {}", e))))
+    .map_err(|e| rustler::Error::Term(Box::new(format!("Could not consume fuel: {e}"))))
 }
 
 fn add_pipe(


### PR DESCRIPTION
Backtraces may change depending on the rustc version.
Fixes test failures after upgrade from 1.66.0 to 1.66.1/1.67.0.