### PR TITLE
Remove macro_use for rustler; Import missing derived structs

### DIFF
--- a/native/wasmex/Cargo.toml
+++ b/native/wasmex/Cargo.toml
@@ -15,9 +15,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = { version = "0.34", default-features = false, features = [
-    "nif_version_2_15", "big_integer"
-] }
+rustler = { version = "0.34", features = ["big_integer"] }
 once_cell = "1.19.0"
 rand = "0.8.5"
 wasmtime = "22.0.0"

--- a/native/wasmex/src/engine.rs
+++ b/native/wasmex/src/engine.rs
@@ -3,7 +3,7 @@
 // see: https://github.com/rust-lang/rust-clippy/issues/9778
 #![allow(clippy::needless_borrow)]
 
-use rustler::{types::Binary, Error, OwnedBinary, Resource, ResourceArc};
+use rustler::{Binary, Error, NifStruct, OwnedBinary, Resource, ResourceArc};
 use std::ops::Deref;
 use std::sync::Mutex;
 use wasmtime::{Config, Engine, WasmBacktraceDetails};

--- a/native/wasmex/src/environment.rs
+++ b/native/wasmex/src/environment.rs
@@ -1,11 +1,3 @@
-use std::sync::{Condvar, Mutex};
-
-use rustler::{
-    types::tuple, Atom, Encoder, Error, ListIterator, MapIterator, OwnedEnv, ResourceArc, Term,
-};
-use wasmtime::{Caller, Engine, FuncType, Linker, Val, ValType};
-use wiggle::anyhow::{self, anyhow};
-
 use crate::{
     atoms,
     caller::{remove_caller, set_caller},
@@ -13,6 +5,12 @@ use crate::{
     memory::MemoryResource,
     store::{StoreData, StoreOrCaller, StoreOrCallerResource},
 };
+use rustler::{
+    types::tuple, Atom, Encoder, Error, ListIterator, MapIterator, OwnedEnv, ResourceArc, Term,
+};
+use std::sync::{Condvar, Mutex};
+use wasmtime::{Caller, Engine, FuncType, Linker, Val, ValType};
+use wiggle::anyhow::{self, anyhow};
 
 pub struct CallbackTokenResource {
     pub token: CallbackToken,

--- a/native/wasmex/src/instance.rs
+++ b/native/wasmex/src/instance.rs
@@ -1,15 +1,3 @@
-use rustler::{
-    dynamic::TermType,
-    env::{OwnedEnv, SavedTerm},
-    types::{tuple::make_tuple, ListIterator},
-    Encoder, Env as RustlerEnv, Error, MapIterator, NifMap, NifResult, ResourceArc, Term,
-};
-use std::ops::Deref;
-use std::sync::Mutex;
-use std::thread;
-
-use wasmtime::{Instance, Linker, Module, Val, ValType};
-
 use crate::{
     atoms,
     environment::{link_imports, link_modules, CallbackTokenResource},
@@ -18,6 +6,16 @@ use crate::{
     printable_term_type::PrintableTermType,
     store::{StoreData, StoreOrCaller, StoreOrCallerResource},
 };
+use rustler::{
+    env::SavedTerm,
+    types::{tuple::make_tuple, ListIterator},
+    Encoder, Env as RustlerEnv, Error, MapIterator, NifMap, NifResult, OwnedEnv, ResourceArc, Term,
+    TermType,
+};
+use std::ops::Deref;
+use std::sync::Mutex;
+use std::thread;
+use wasmtime::{Instance, Linker, Module, Val, ValType};
 
 #[derive(NifMap)]
 pub struct LinkedModule {

--- a/native/wasmex/src/lib.rs
+++ b/native/wasmex/src/lib.rs
@@ -10,7 +10,4 @@ pub mod pipe;
 pub mod printable_term_type;
 pub mod store;
 
-#[macro_use]
-extern crate rustler;
-
-rustler::init! {"Elixir.Wasmex.Native"}
+rustler::init!("Elixir.Wasmex.Native");

--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -1,14 +1,11 @@
 //! Memory API of an WebAssembly instance.
 
-use std::io::Write;
-use std::sync::Mutex;
-
-use rustler::{Atom, Binary, Error, NewBinary, NifResult, ResourceArc, Term};
-
-use wasmtime::{Instance, Memory, Store};
-
 use crate::store::{StoreOrCaller, StoreOrCallerResource};
 use crate::{atoms, instance};
+use rustler::{Atom, Binary, Error, NewBinary, NifResult, ResourceArc, Term};
+use std::io::Write;
+use std::sync::Mutex;
+use wasmtime::{Instance, Memory, Store};
 
 pub struct MemoryResource {
     pub inner: Mutex<Memory>,

--- a/native/wasmex/src/module.rs
+++ b/native/wasmex/src/module.rs
@@ -1,17 +1,14 @@
-use rustler::{
-    types::{binary::Binary, tuple::make_tuple},
-    Encoder, Env, NifResult, OwnedBinary, ResourceArc, Term,
-};
-use std::{collections::HashMap, sync::Mutex};
-
-use wasmtime::{
-    ExternType, FuncType, GlobalType, MemoryType, Module, Mutability, RefType, TableType, ValType,
-};
-
 use crate::{
     atoms,
     engine::{unwrap_engine, EngineResource},
     store::{StoreOrCaller, StoreOrCallerResource},
+};
+use rustler::{
+    types::tuple::make_tuple, Binary, Encoder, Env, NifResult, OwnedBinary, ResourceArc, Term,
+};
+use std::{collections::HashMap, sync::Mutex};
+use wasmtime::{
+    ExternType, FuncType, GlobalType, MemoryType, Module, Mutability, RefType, TableType, ValType,
 };
 
 pub struct ModuleResource {

--- a/native/wasmex/src/pipe.rs
+++ b/native/wasmex/src/pipe.rs
@@ -1,16 +1,14 @@
 //! A Pipe is a file buffer hold in memory.
 //! It can, for example, be used to replace stdin/stdout/stderr of a WASI module.
 
-use std::any::Any;
-use std::io::{self, Read, Seek};
-use std::io::{Cursor, Write};
-use std::sync::{Arc, Mutex, RwLock};
-
 use rustler::{Encoder, ResourceArc, Term};
-
-use wasi_common::file::{FdFlags, FileType};
-use wasi_common::Error;
-use wasi_common::WasiFile;
+use std::any::Any;
+use std::io::{self, Cursor, Read, Seek, Write};
+use std::sync::{Arc, Mutex, RwLock};
+use wasi_common::{
+    file::{FdFlags, FileType},
+    Error, WasiFile,
+};
 
 use crate::atoms;
 

--- a/native/wasmex/src/printable_term_type.rs
+++ b/native/wasmex/src/printable_term_type.rs
@@ -1,4 +1,4 @@
-use rustler::dynamic::TermType;
+use rustler::TermType;
 
 // PrintableTermType is a workaround for rustler::dynamic::TermType not having the Debug trait.
 pub enum PrintableTermType {

--- a/native/wasmex/src/store.rs
+++ b/native/wasmex/src/store.rs
@@ -3,18 +3,17 @@
 // see: https://github.com/rust-lang/rust-clippy/issues/9778
 #![allow(clippy::needless_borrow)]
 
-use rustler::{Error, ResourceArc};
+use crate::{
+    caller::{get_caller, get_caller_mut},
+    engine::{unwrap_engine, EngineResource},
+    pipe::{Pipe, PipeResource},
+};
+use rustler::{Error, NifStruct, ResourceArc};
 use std::{collections::HashMap, sync::Mutex};
 use wasi_common::{sync::WasiCtxBuilder, WasiCtx};
 use wasmtime::{
     AsContext, AsContextMut, Engine, Store, StoreContext, StoreContextMut, StoreLimits,
     StoreLimitsBuilder,
-};
-
-use crate::{
-    caller::{get_caller, get_caller_mut},
-    engine::{unwrap_engine, EngineResource},
-    pipe::{Pipe, PipeResource},
 };
 
 #[derive(Debug, NifStruct)]


### PR DESCRIPTION
@tessi I've cleaned up the features for rustler. The defaults include `nif_version_2_15` and `derive` is ignored and its functionality is unconditionally enabled [#621](https://github.com/rusterlium/rustler/pull/621).