### PR TITLE
feat: add support for wasmtime's underlying memory64 implementation

### DIFF
--- a/lib/wasmex/engine_config.ex
+++ b/lib/wasmex/engine_config.ex
@@ -18,12 +18,14 @@ defmodule Wasmex.EngineConfig do
 
   defstruct consume_fuel: false,
             cranelift_opt_level: :none,
-            wasm_backtrace_details: false
+            wasm_backtrace_details: false,
+            memory64: false
 
   @type t :: %__MODULE__{
           consume_fuel: boolean(),
           cranelift_opt_level: :none | :speed | :speed_and_size,
-          wasm_backtrace_details: boolean()
+          wasm_backtrace_details: boolean(),
+          memory64: boolean()
         }
 
   @doc ~S"""
@@ -48,6 +50,21 @@ defmodule Wasmex.EngineConfig do
   @spec consume_fuel(t(), boolean()) :: t()
   def consume_fuel(%__MODULE__{} = config, consume_fuel) do
     %__MODULE__{config | consume_fuel: consume_fuel}
+  end
+
+  @doc ~S"""
+  Configures whether the WebAssembly memory type is 64-bit.
+
+  ## Example
+
+      iex> config = %Wasmex.EngineConfig{}
+      ...>          |> Wasmex.EngineConfig.memory64(true)
+      iex> config.memory64
+      true
+  """
+  @spec memory64(t(), boolean()) :: t()
+  def memory64(%__MODULE__{} = config, memory64) do
+    %__MODULE__{config | memory64: memory64}
   end
 
   @doc """

--- a/native/wasmex/src/engine.rs
+++ b/native/wasmex/src/engine.rs
@@ -11,6 +11,7 @@ pub struct ExEngineConfig {
     consume_fuel: bool,
     wasm_backtrace_details: bool,
     cranelift_opt_level: rustler::Atom,
+    memory64: bool,
 }
 
 #[rustler::resource_impl()]
@@ -66,6 +67,7 @@ pub(crate) fn engine_config(engine_config: ExEngineConfig) -> Config {
     config.consume_fuel(engine_config.consume_fuel);
     config.wasm_backtrace_details(backtrace_details);
     config.cranelift_opt_level(cranelift_opt_level);
+    config.wasm_memory64(engine_config.memory64);
     config
 }
 

--- a/test/wasmex/engine_config_test.exs
+++ b/test/wasmex/engine_config_test.exs
@@ -31,4 +31,12 @@ defmodule Wasmex.EngineConfigTest do
       assert %{wasm_backtrace_details: true} = EngineConfig.wasm_backtrace_details(config, true)
     end
   end
+
+  describe t(&EngineConfig.memory64/1) do
+    test "sets the memory64 option" do
+      config = %EngineConfig{}
+      assert %{memory64: false} = EngineConfig.memory64(config, false)
+      assert %{memory64: true} = EngineConfig.memory64(config, true)
+    end
+  end
 end

--- a/test/wasmex/engine_test.exs
+++ b/test/wasmex/engine_test.exs
@@ -24,6 +24,7 @@ defmodule Wasmex.EngineTest do
                %EngineConfig{}
                |> EngineConfig.consume_fuel(true)
                |> EngineConfig.cranelift_opt_level(:speed)
+               |> EngineConfig.memory64(true)
                |> Engine.new()
     end
   end


### PR DESCRIPTION
I noticed that the `EngineConfig{}` doesn't support the `memory64` option offered by wasmtime. This PR adds support and tests for that.

Thanks for building wasmex!