### PR TITLE
Provide pid in imports callback context

### DIFF
--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -439,7 +439,14 @@ defmodule Wasmex do
   @spec module(pid()) :: {:ok, Wasmex.Module.t()} | {:error, any()}
   def module(pid), do: GenServer.call(pid, {:module})
 
+  @doc ~S"""
+  Returns the `Wasmex.Instance` of the Wasm instance.
 
+  ## Example
+
+      iex> {:ok, pid} = Wasmex.start_link(%{bytes: File.read!(TestHelper.wasm_test_file_path())})
+      iex> {:ok, %Wasmex.Instance{}} = Wasmex.instance(pid)
+  """
   @spec instance(pid()) :: {:ok, Wasmex.Instance.t()} | {:error, any()}
   def instance(pid), do: GenServer.call(pid, {:instance})
 

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -74,7 +74,8 @@ defmodule Wasmex do
 
       %{
         memory: %Wasmex.Memory{},
-        caller: %Wasmex.StoreOrCaller{}
+        caller: %Wasmex.StoreOrCaller{},
+        pid: pid(),
       } = context
 
   The `caller` MUST be used instead of a `store` in Wasmex API functions.
@@ -517,7 +518,8 @@ defmodule Wasmex do
         context,
         %{
           memory: Wasmex.Memory.__wrap_resource__(Map.get(context, :memory)),
-          caller: Wasmex.StoreOrCaller.__wrap_resource__(Map.get(context, :caller))
+          caller: Wasmex.StoreOrCaller.__wrap_resource__(Map.get(context, :caller)),
+          pid: self()
         }
       )
 

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -440,7 +440,7 @@ defmodule Wasmex do
   def module(pid), do: GenServer.call(pid, {:module})
 
 
-  @spec instance() :: {:ok, Wasmex.Instance.t()} | {:error, any()}
+  @spec instance(pid()) :: {:ok, Wasmex.Instance.t()} | {:error, any()}
   def instance(pid), do: GenServer.call(pid, {:instance})
 
   defp stringify_keys(struct) when is_struct(struct), do: struct

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -448,7 +448,7 @@ defmodule WasmexTest do
 
       imports = %{
         env: %{add_import: {:fn, [:i32, :i32], [:i32], fn %{instance: instance, caller: caller}, a, b -> 
-          Wasmex.Instance.call_exported_function(caller, instance, "call_add", [a,b], :from) 
+          Wasmex.Instance.call_exported_function(caller, instance, "call_add", [a, b], :from) 
           receive do {
             :returned_function_call, {:ok, [result]}, :from} -> :ok 
             result 

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -447,14 +447,26 @@ defmodule WasmexTest do
       """
 
       imports = %{
-        env: %{add_import: {:fn, [:i32, :i32], [:i32], fn %{instance: instance, caller: caller}, a, b -> 
-          Wasmex.Instance.call_exported_function(caller, instance, "call_add", [a, b], :from) 
-          receive do {
-            :returned_function_call, {:ok, [result]}, :from} -> :ok 
-            result 
-          after 1000 ->  
-            raise "timeout on exported function call" end
-        end}}
+        env: %{
+          add_import:
+            {:fn, [:i32, :i32], [:i32],
+             fn %{instance: instance, caller: caller}, a, b ->
+               Wasmex.Instance.call_exported_function(caller, instance, "call_add", [a, b], :from)
+
+               receive do
+                 {
+                   :returned_function_call,
+                   {:ok, [result]},
+                   :from
+                 } ->
+                   :ok
+                   result
+               after
+                 1000 ->
+                   raise "timeout on exported function call"
+               end
+             end}
+        }
       }
 
       {:ok, store} = Wasmex.Store.new()

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -427,4 +427,40 @@ defmodule WasmexTest do
       assert Wasmex.Memory.read_string(store, memory, string_ptr, length) == "Hello World!"
     end
   end
+
+  describe "call exported function in imported function callback" do
+    test "using instance in callback" do
+      wat = """
+      (module
+        (func $add_import (import "env" "add_import") (param i32 i32) (result i32))
+
+        (func $call_import (export "call_import") (param i32 i32) (result i32)
+          (call $add_import (local.get 0) (local.get 1))
+        )
+
+        (func $call_add (export "call_add") (param i32 i32) (result i32)
+          local.get 0
+          local.get 1
+          i32.add
+        )
+      )
+      """
+
+      imports = %{
+        env: %{add_import: {:fn, [:i32, :i32], [:i32], fn %{instance: instance, caller: caller}, a, b -> 
+          Wasmex.Instance.call_exported_function(caller, instance, "call_add", [a,b], :from) 
+          receive do {
+            :returned_function_call, {:ok, [result]}, :from} -> :ok 
+            result 
+          after 1000 ->  
+            raise "timeout on exported function call" end
+        end}}
+      }
+
+      {:ok, store} = Wasmex.Store.new()
+      {:ok, module} = Wasmex.Module.compile(store, wat)
+      pid = start_supervised!({Wasmex, %{store: store, module: module, imports: imports}})
+      assert Wasmex.call_function(pid, :call_import, [1, 2]) == {:ok, [3]}
+    end
+  end
 end


### PR DESCRIPTION
Then we can call exported functions in imported functions.