### PR TITLE
bump rustler_precompiled

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Wasmex.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:rustler_precompiled, "~> 0.7.2"},
+      {:rustler_precompiled, "~> 0.8.2"},
       {:rustler, "~> 0.34.0"},
       {:ex_doc, "~> 0.34.1", only: [:dev, :test]},
       {:credo, "~> 1.7.5", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
Need to bump rustler_precomplied so the CA_CERTS env var can be used for HTTP requests.