### PR TITLE
allow options to be a keyword list

### DIFF
--- a/lib/wasmex/components.ex
+++ b/lib/wasmex/components.ex
@@ -22,6 +22,22 @@ defmodule Wasmex.Components do
     end
   end
 
+  def start_link(opts) when is_list(opts) do
+    with {:ok, store} <- build_store(opts),
+         component_bytes <- Keyword.get(opts, :bytes),
+         {:ok, component} <- Wasmex.Components.Component.new(store, component_bytes) do
+      GenServer.start_link(__MODULE__, %{store: store, component: component}, opts)
+    end
+  end
+
+  defp build_store(opts) do
+    if wasi_options = Keyword.get(opts, :wasi) do
+      Wasmex.Components.Store.new_wasi(wasi_options)
+    else
+      Wasmex.Components.Store.new()
+    end
+  end
+
   @spec call_function(pid(), String.t() | atom(), list(number()), pos_integer()) ::
           {:ok, list(number())} | {:error, any()}
   def call_function(pid, name, params, timeout \\ 5000) do

--- a/test/components/components_test.exs
+++ b/test/components/components_test.exs
@@ -2,7 +2,7 @@ defmodule Wasmex.ComponentsTest do
   use ExUnit.Case, async: true
   alias Wasmex.Wasi.WasiP2Options
 
-  test "interacting with a component server" do
+  test "interacting with a component GenServer" do
     component_bytes = File.read!("test/component_fixtures/component_types/component_types.wasm")
     component_pid = start_supervised!({Wasmex.Components, %{bytes: component_bytes}})
     assert {:ok, "mom"} = Wasmex.Components.call_function(component_pid, "id-string", ["mom"])
@@ -20,5 +20,14 @@ defmodule Wasmex.ComponentsTest do
     assert {:ok, time} = Wasmex.Components.call_function(component_pid, "get-time", [])
 
     assert time =~ Date.utc_today() |> Date.to_iso8601()
+  end
+
+  test "register by name" do
+    component_bytes = File.read!("test/component_fixtures/component_types/component_types.wasm")
+
+    {:ok, _pid} =
+      start_supervised({Wasmex.Components, bytes: component_bytes, name: ComponentTypes})
+
+    assert {:ok, "mom"} = Wasmex.Components.call_function(ComponentTypes, "id-string", ["mom"])
   end
 end


### PR DESCRIPTION
Very small PR to allow options to be a kw list for component GenServer. This makes it a little easier to add a component based genserver as a worker in application.ex. We might want to do the same for `Wasmex` I just didn't get to that yet :)