### PR TITLE
record fields as atoms

### DIFF
--- a/native/wasmex/Cargo.lock
+++ b/native/wasmex/Cargo.lock
@@ -1437,6 +1437,7 @@ dependencies = [
  "num-bigint",
  "regex-lite",
  "rustler_codegen",
+ "serde",
 ]
 
 [[package]]

--- a/native/wasmex/Cargo.toml
+++ b/native/wasmex/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = { version = "0.35", features = ["big_integer"] }
+rustler = { version = "0.35", features = ["big_integer", "serde"] }
 once_cell = "1.20.2"
 rand = "0.8.5"
 wasmtime = "26.0.1"

--- a/native/wasmex/src/component_instance.rs
+++ b/native/wasmex/src/component_instance.rs
@@ -117,7 +117,7 @@ fn term_to_val(param_term: &Term, param_type: &Type) -> Result<Val, Error> {
             let decoded_map = param_term.decode::<HashMap<Term, Term>>()?;
             let terms = decoded_map
                 .iter()
-                .map(|(key_term, val)| (key_from_term(key_term), val))
+                .map(|(key_term, val)| (term_to_field_name(key_term), val))
                 .collect::<Vec<(String, &Term)>>();
             for field in record.fields() {
                 let field_term_option = terms.iter().find(|(k, _)| k == field.name);
@@ -148,7 +148,7 @@ fn term_to_val(param_term: &Term, param_type: &Type) -> Result<Val, Error> {
     }
 }
 
-fn key_from_term(key_term: &Term) -> String {
+fn term_to_field_name(key_term: &Term) -> String {
     match key_term.get_type() {
         TermType::Atom => key_term.atom_to_string().unwrap(),
         _ => key_term.decode::<String>().unwrap(),

--- a/native/wasmex/src/component_instance.rs
+++ b/native/wasmex/src/component_instance.rs
@@ -155,7 +155,7 @@ fn key_from_term(key_term: &Term) -> String {
     }
 }
 
-fn field_name_to_term<'a>(env: &rustler::Env<'a>, field_name: &String) -> Term<'a> {
+fn field_name_to_term<'a>(env: &rustler::Env<'a>, field_name: &str) -> Term<'a> {
     rustler::serde::atoms::str_to_term(env, field_name).unwrap()
 }
 

--- a/native/wasmex/src/component_instance.rs
+++ b/native/wasmex/src/component_instance.rs
@@ -117,7 +117,7 @@ fn term_to_val(param_term: &Term, param_type: &Type) -> Result<Val, Error> {
             let decoded_map = param_term.decode::<HashMap<Term, Term>>()?;
             let terms = decoded_map
                 .iter()
-                .map(|(key, val)| (key.decode::<String>().unwrap(), val))
+                .map(|(key_term, val)| (key_from_term(key_term), val))
                 .collect::<Vec<(String, &Term)>>();
             for field in record.fields() {
                 let field_term_option = terms.iter().find(|(k, _)| k == field.name);
@@ -146,6 +146,17 @@ fn term_to_val(param_term: &Term, param_type: &Type) -> Result<Val, Error> {
             term_type, val_type
         )))),
     }
+}
+
+fn key_from_term(key_term: &Term) -> String {
+    match key_term.get_type() {
+        TermType::Atom => key_term.atom_to_string().unwrap(),
+        _ => key_term.decode::<String>().unwrap(),
+    }
+}
+
+fn field_name_to_term<'a>(env: &rustler::Env<'a>, field_name: &String) -> Term<'a> {
+    rustler::serde::atoms::str_to_term(env, field_name).unwrap()
 }
 
 fn encode_result(env: rustler::Env, vals: Vec<Val>) -> Term {
@@ -182,8 +193,8 @@ fn val_to_term<'a>(val: &Val, env: rustler::Env<'a>) -> Term<'a> {
         Val::Record(record) => {
             let converted_pairs = record
                 .iter()
-                .map(|(key, val)| (key, val_to_term(val, env)))
-                .collect::<Vec<(&String, Term<'a>)>>();
+                .map(|(key, val)| (field_name_to_term(&env, key), val_to_term(val, env)))
+                .collect::<Vec<(Term, Term)>>();
             Term::map_from_pairs(env, converted_pairs.as_slice()).unwrap()
         }
         Val::Tuple(tuple) => {

--- a/test/components/component_types_test.exs
+++ b/test/components/component_types_test.exs
@@ -33,10 +33,14 @@ defmodule Wasm.Components.ComponentTypesTest do
   end
 
   test "records", %{instance: instance} do
-    # don't love this yet, be nicer to support atom keys
-    assert {:ok, %{"x" => 1, "y" => 2}} =
+    assert {:ok, %{x: 1, y: 2}} =
              Wasmex.Components.Instance.call_function(instance, "id-record", [
                %{"x" => 1, "y" => 2}
+             ])
+
+    assert {:ok, %{x: 1, y: 2}} =
+             Wasmex.Components.Instance.call_function(instance, "id-record", [
+               %{x: 1, y: 2}
              ])
 
     assert {:error, _error} =


### PR DESCRIPTION
We may or may not wish this to be configurable, but to start with having field names on records be atoms (when possible) seems reasonable.