### PR TITLE
Support passing an Instance to Wasmex.start_link

### DIFF
--- a/lib/wasmex/instance.ex
+++ b/lib/wasmex/instance.ex
@@ -77,6 +77,7 @@ defmodule Wasmex.Instance do
       when is_map(imports) and is_list(links) do
     %Wasmex.StoreOrCaller{resource: store_or_caller_resource} = store_or_caller
     %Wasmex.Module{resource: module_resource} = module
+    imports = Wasmex.Utils.stringify_keys(imports)
 
     links =
       links

--- a/lib/wasmex/store.ex
+++ b/lib/wasmex/store.ex
@@ -67,6 +67,7 @@ defmodule Wasmex.Store do
           {:error, reason :: binary()} | {:ok, StoreOrCaller.t()}
   def new_wasi(%WasiOptions{} = options, store_limits \\ nil, engine \\ nil) do
     %Engine{resource: engine_resource} = engine || Engine.default()
+    options = Wasmex.Utils.stringify_keys(options)
 
     case Wasmex.Native.store_new_wasi(
            options,

--- a/lib/wasmex/utils.ex
+++ b/lib/wasmex/utils.ex
@@ -1,0 +1,23 @@
+defmodule Wasmex.Utils do
+  @moduledoc """
+  Utility functions for Wasmex.
+  """
+
+  @doc """
+  Stringifies the keys of a struct or map.
+  """
+  def stringify_keys(struct) when is_struct(struct), do: struct
+
+  def stringify_keys(map) when is_map(map) do
+    for {key, val} <- map, into: %{}, do: {stringify(key), stringify_keys(val)}
+  end
+
+  def stringify_keys(list) when is_list(list) do
+    for val <- list, into: [], do: stringify_keys(val)
+  end
+
+  def stringify_keys(value), do: value
+
+  def stringify(s) when is_binary(s), do: s
+  def stringify(s) when is_atom(s), do: Atom.to_string(s)
+end

--- a/test/component_type_conversions_test.exs
+++ b/test/component_type_conversions_test.exs
@@ -1,6 +1,5 @@
 defmodule Wasmex.ComponentTypeConversionsTest do
   use ExUnit.Case, async: true
-  doctest Wasmex
 
   alias Wasmex.Wasi.WasiP2Options
 

--- a/test/wasi_test.exs
+++ b/test/wasi_test.exs
@@ -1,6 +1,5 @@
 defmodule WasiTest do
   use ExUnit.Case, async: true
-  doctest Wasmex
 
   alias Wasmex.Wasi.PreopenOptions
   alias Wasmex.Wasi.WasiOptions


### PR DESCRIPTION
Adds support to pass an Instance to Wasmex.start_link. This is an attempt to allow serialised modules to be cached and be un-serialized later. This was only possible when users implemented their own GenServer, because the default Wasmex GenServer always instantiated a new module no matter what.