### PR TITLE
downgrade release binary build runners from ubuntu-latest to ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,17 +31,17 @@ jobs:
         nif: ["2.15"]
         job:
           # cranelift-codegen panics at 'error when identifying target: "no supported isa found for arch `arm`"'
-          # - { target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-latest, use-cross: true }
-          - { target: aarch64-unknown-linux-musl, os: ubuntu-latest, use-cross: true }
+          # - { target: arm-unknown-linux-gnueabihf , os: ubuntu-22.04 , use-cross: true }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true }
           - { target: aarch64-apple-darwin, os: macos-15 }
           - { target: x86_64-apple-darwin, os: macos-15 }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-latest, use-cross: true }
-          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-latest, use-cross: true, cargo-args: "--no-default-features"}
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true }
+          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true, cargo-args: "--no-default-features"}
           - { target: x86_64-pc-windows-gnu, os: windows-2022 }
           - { target: x86_64-pc-windows-msvc, os: windows-2022 }
-          - { target: x86_64-unknown-freebsd, os: ubuntu-latest, use-cross: true, cross-version: v0.2.5 }
+          - { target: x86_64-unknown-freebsd, os: ubuntu-22.04, use-cross: true, cross-version: v0.2.5 }
 
     steps:
       - name: Checkout source code


### PR DESCRIPTION
fixes #774

We are building prebuilt binaries with too recent libraries (specifically glibc) and better roll back to an older available ubuntu build. Alternatives would be building with tailored docker containers - but this looks like the quick and easy win.