### PR TITLE
add support to compile wat files to wasm binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Types of changes
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.11.2 - unreleased]
+
+### Added
+
+- Added support for compiling Wasm text format (WAT) to Wasm binaries -> `Wasmex.Wat.to_wasm/1`
+
 ## [0.11.1 - 2025-05-23]
 
 ### Changed

--- a/lib/wasmex/native.ex
+++ b/lib/wasmex/native.ex
@@ -97,6 +97,8 @@ defmodule Wasmex.Native do
 
   def wit_exported_functions(_path, _wit), do: error()
 
+  def wat_to_wasm(_wat), do: error()
+
   # When the NIF is loaded, it will override functions in this module.
   # Calling error is handles the case when the nif could not be loaded.
   defp error, do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/wasmex/wat.ex
+++ b/lib/wasmex/wat.ex
@@ -1,0 +1,15 @@
+defmodule Wasmex.Wat do
+  @moduledoc """
+  Utilities to work with Web Assembly Text (.wat) files.
+  """
+
+  @doc """
+  Converts a Wasm text file to a Wasm binary.
+  """
+  def to_wasm(wat) do
+    case Wasmex.Native.wat_to_wasm(wat) do
+      {:error, error} -> {:error, error}
+      wasm -> {:ok, wasm}
+    end
+  end
+end

--- a/native/wasmex/src/lib.rs
+++ b/native/wasmex/src/lib.rs
@@ -12,6 +12,7 @@ pub mod module;
 pub mod pipe;
 pub mod printable_term_type;
 pub mod store;
+pub mod wat;
 pub mod wit;
 
 rustler::init!("Elixir.Wasmex.Native");

--- a/native/wasmex/src/wat.rs
+++ b/native/wasmex/src/wat.rs
@@ -1,0 +1,10 @@
+use rustler::{Binary, NifResult};
+
+#[rustler::nif(name = "wat_to_wasm")]
+pub fn to_wasm(env: rustler::Env, wat: String) -> NifResult<Binary> {
+    let bytes = wat::parse_str(&wat)
+        .map_err(|e| rustler::Error::Term(Box::new(format!("Failed to parse WAT: {}", e))))?;
+    let mut binary = rustler::OwnedBinary::new(bytes.len()).unwrap();
+    binary.as_mut_slice().copy_from_slice(&bytes);
+    Ok(binary.release(env))
+}

--- a/test/wat_test.exs
+++ b/test/wat_test.exs
@@ -1,0 +1,56 @@
+defmodule WatTest do
+  use ExUnit.Case, async: true
+
+  test "converting a Wasm text file to a Wasm core module" do
+    wat = """
+    (module
+      (func (export "add") (param i32) (param i32) (result i32)
+        local.get 0
+        local.get 1
+        i32.add
+        return
+      )
+    )
+    """
+
+    assert {:ok, wasm} = Wasmex.Wat.to_wasm(wat)
+    assert {:ok, pid} = Wasmex.start_link(%{bytes: wasm})
+    assert {:ok, [42]} = Wasmex.call_function(pid, "add", [50, -8])
+  end
+
+  test "compile error" do
+    wat = "not a wat file"
+    assert {:error, error} = Wasmex.Wat.to_wasm(wat)
+
+    assert error ==
+             "Failed to parse WAT: expected `(`\n     --> <anon>:1:1\n      |\n    1 | not a wat file\n      | ^"
+  end
+
+  test "converting a Wasm text file to a Wasm component" do
+    wat = """
+    (component
+      (core module $LengthCoreWasm
+        (func (export "length") (param $ptr i32) (param $len i32) (result i32)
+          local.get $len
+        )
+        (memory (export "mem") 1)
+        (func (export "realloc") (param i32 i32 i32 i32) (result i32)
+          i32.const 0
+        )
+      )
+      (core instance $length_instance (instantiate $LengthCoreWasm))
+      (func (export "length") (param "input" string) (result u32)
+        (canon lift
+          (core func $length_instance "length")
+          (memory $length_instance "mem")
+          (realloc (func $length_instance "realloc"))
+        )
+      )
+    )
+    """
+
+    assert {:ok, wasm} = Wasmex.Wat.to_wasm(wat)
+    assert {:ok, pid} = Wasmex.Components.start_link(%{bytes: wasm})
+    assert {:ok, 9} = Wasmex.Components.call_function(pid, "length", ["hi wasmex"])
+  end
+end


### PR DESCRIPTION
useful for testing and quick demos

```
wat = """
(component
  (core module $SumCoreWasm
    (func (export "sum") (param $a i32) (param $b i32) (result i32)
      local.get $a
      local.get $b
      i32.add
    )
    (memory (export "mem") 1)
    (func (export "realloc") (param i32 i32 i32 i32) (result i32)
      i32.const 0    
    )
  )
  (core instance $sum_instance (instantiate $SumCoreWasm))
  (func (export "sum") (param "a" s32) (param "b" s32) (result s32)
    (canon lift
      (core func $sum_instance "sum")
      (memory $sum_instance "mem")
      (realloc (func $sum_instance "realloc"))
    )
  )
)
"""
{:ok, wasm} = Wasmex.Wat.to_wasm(wat)
```