### PR TITLE
feat: allow exported interfaces to be called

### DIFF
--- a/native/wasmex/src/component_instance.rs
+++ b/native/wasmex/src/component_instance.rs
@@ -242,7 +242,27 @@ fn component_execute_function(
         }
     };
 
-    let function_result = instance.get_func(&mut *component_store, func_name.clone());
+    let function_result = match func_name.split_once("#") {
+        Some((left, right)) => {
+            match instance.get_export(&mut *component_store, None, &left) {
+                Some(export_index) => {
+                    dbg!(&export_index);
+                    // instance.get_func(&mut *component_store, export_index)
+                    match instance.get_export(&mut *component_store, Some(&export_index), &right) {
+                        Some(export_index) => {
+                            dbg!(&export_index);
+                            instance.get_func(&mut *component_store, export_index)
+                        }
+                        None => None
+                    }
+                }
+                None => None
+            }
+        }
+        None => instance.get_func(&mut *component_store, func_name.clone())
+    };
+
+    // let function_result = instance.get_func(&mut *component_store, func_name.clone());
     let function = match function_result {
         Some(func) => func,
         None => {

--- a/test/component_fixtures/export-interface/adder.js
+++ b/test/component_fixtures/export-interface/adder.js
@@ -1,0 +1,7 @@
+function add(a, b) {
+  return a + b
+}
+
+export const adder = {
+  add
+}

--- a/test/component_fixtures/export-interface/adder.wit
+++ b/test/component_fixtures/export-interface/adder.wit
@@ -1,0 +1,9 @@
+package local:adder;
+
+interface adder {
+  add: func(a: u32, b: u32) -> u32;
+}
+
+world root {
+  export adder;
+}

--- a/test/component_fixtures/export-interface/build.sh
+++ b/test/component_fixtures/export-interface/build.sh
@@ -1,0 +1,1 @@
+npx @bytecodealliance/jco componentize -d all -w adder.wit -o adder.wasm adder.js

--- a/test/components/component_test.exs
+++ b/test/components/component_test.exs
@@ -23,6 +23,25 @@ defmodule Wasmex.WasmComponentsTest do
     assert greeting =~ "Hello"
   end
 
+  test "call function from interface" do
+    {:ok, engine} = Wasmex.Engine.new(%EngineConfig{debug_info: true})
+
+    {:ok, store} =
+      Wasmex.Components.Store.new_wasi(
+        %WasiP2Options{},
+        %Wasmex.StoreLimits{},
+        engine
+      )
+
+    component_bytes = File.read!("test/component_fixtures/export-interface/adder.wasm")
+
+    instance =
+      start_supervised!({HelloWorld, bytes: component_bytes, store: store})
+
+    assert {:ok, answer} = Wasmex.Components.call_function(instance, "local:adder/adder#add", [45, 123])
+    assert answer == 45+123
+  end
+
   describe "error handling" do
     setup do
       component_bytes = File.read!("test/component_fixtures/hello_world/hello_world.wasm")


### PR DESCRIPTION
Extremely rough implemention (see the dbg! macros being called) on how it could work to call an interface. for issue https://github.com/tessi/wasmex/issues/781