### PR TITLE
Enable support for the WebAssembly exception handling proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Types of changes
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [Unreleased]
+
+### Added
+
+* Added an option to enable the [WebAssembly exception handling proposal](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md) via `Wasmex.EngineConfig.wasm_exceptions/2`. This supports WASM modules that use `setjmp`/`longjmp` emulation (e.g., modules built with [Emscripten](https://emscripten.org/) using `-s SUPPORT_LONGJMP=wasm -s WASM_LEGACY_EXCEPTIONS=0`).
+
 ## [0.14.0 - 2025-12-16]
 
 ### Changed

--- a/lib/wasmex/engine_config.ex
+++ b/lib/wasmex/engine_config.ex
@@ -10,6 +10,7 @@ defmodule Wasmex.EngineConfig do
     * `:debug_info` - Configures whether DWARF debug information will be emitted during compilation. This defaults to `false`.
     * `:memory64` - Whether or not to use 64-bit memory. This defaults to `false`.
     * `:wasm_component_model` - Whether or not to use the WebAssembly component model. This defaults to `true`.
+    * `:wasm_exceptions` - Whether or not to enable the WebAssembly exception handling proposal. This defaults to `false`.
 
   ## Example
 
@@ -24,7 +25,8 @@ defmodule Wasmex.EngineConfig do
             wasm_backtrace_details: false,
             memory64: false,
             wasm_component_model: true,
-            debug_info: false
+            debug_info: false,
+            wasm_exceptions: false
 
   @type t :: %__MODULE__{
           consume_fuel: boolean(),
@@ -32,7 +34,8 @@ defmodule Wasmex.EngineConfig do
           wasm_backtrace_details: boolean(),
           memory64: boolean(),
           wasm_component_model: boolean(),
-          debug_info: boolean()
+          debug_info: boolean(),
+          wasm_exceptions: boolean()
         }
 
   @doc ~S"""
@@ -108,5 +111,24 @@ defmodule Wasmex.EngineConfig do
   @spec wasm_backtrace_details(t(), boolean()) :: t()
   def wasm_backtrace_details(%__MODULE__{} = config, wasm_backtrace_details) do
     %__MODULE__{config | wasm_backtrace_details: wasm_backtrace_details}
+  end
+
+  @doc ~S"""
+  Configures whether the WebAssembly exception handling proposal is enabled.
+
+  This enables support for the WebAssembly exception handling proposal,
+  which allows Wasm modules to use try/catch/throw instructions.
+  Required for running WASM modules that use setjmp/longjmp emulation.
+
+  ## Example
+
+      iex> config = %Wasmex.EngineConfig{}
+      ...>          |> Wasmex.EngineConfig.wasm_exceptions(true)
+      iex> config.wasm_exceptions
+      true
+  """
+  @spec wasm_exceptions(t(), boolean()) :: t()
+  def wasm_exceptions(%__MODULE__{} = config, wasm_exceptions) do
+    %__MODULE__{config | wasm_exceptions: wasm_exceptions}
   end
 end

--- a/native/wasmex/src/engine.rs
+++ b/native/wasmex/src/engine.rs
@@ -28,6 +28,7 @@ pub struct ExEngineConfig {
     memory64: bool,
     wasm_component_model: bool,
     debug_info: bool,
+    wasm_exceptions: bool,
 }
 
 #[rustler::resource_impl()]
@@ -89,6 +90,7 @@ pub(crate) fn engine_config(engine_config: ExEngineConfig) -> Config {
     config.wasm_memory64(engine_config.memory64);
     config.wasm_component_model(engine_config.wasm_component_model);
     config.debug_info(engine_config.debug_info);
+    config.wasm_exceptions(engine_config.wasm_exceptions);
 
     config
 }

--- a/test/wasmex/engine_config_test.exs
+++ b/test/wasmex/engine_config_test.exs
@@ -39,4 +39,12 @@ defmodule Wasmex.EngineConfigTest do
       assert %{memory64: true} = EngineConfig.memory64(config, true)
     end
   end
+
+  describe t(&EngineConfig.wasm_exceptions/1) do
+    test "sets the wasm_exceptions option" do
+      config = %EngineConfig{}
+      assert %{wasm_exceptions: false} = EngineConfig.wasm_exceptions(config, false)
+      assert %{wasm_exceptions: true} = EngineConfig.wasm_exceptions(config, true)
+    end
+  end
 end

--- a/test/wasmex/engine_test.exs
+++ b/test/wasmex/engine_test.exs
@@ -25,6 +25,7 @@ defmodule Wasmex.EngineTest do
                |> EngineConfig.consume_fuel(true)
                |> EngineConfig.cranelift_opt_level(:speed)
                |> EngineConfig.memory64(true)
+               |> EngineConfig.wasm_exceptions(true)
                |> Engine.new()
     end
   end


### PR DESCRIPTION
This PR adds an option to enable the [WebAssembly exception handling proposal](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md) (Phase 4, Wasm 3.0 with exnref) via a new `wasm_exceptions` option in `EngineConfig`. This defaults to being disabled, which matches the status quo.
