### PR TITLE
Fix some overly strict typespecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Types of changes
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [Unreleased]
+
+### Fixed
+
+- Corrected public typespecs to accept registered GenServer names and to reflect the full range of WebAssembly component parameter and return values. Thanks @Sorixelle (#971)
+
 ## [0.14.0 - 2025-12-16]
 
 ### Changed

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -307,7 +307,7 @@ defmodule Wasmex do
       iex> Wasmex.function_exists(pid, "something_else")
       false
   """
-  @spec function_exists(pid(), String.t()) :: boolean()
+  @spec function_exists(GenServer.server(), String.t()) :: boolean()
   def function_exists(pid, name) do
     GenServer.call(pid, {:exported_function_exists, Wasmex.Utils.stringify(name)})
   end
@@ -401,7 +401,7 @@ defmodule Wasmex do
 
   In the example above, we specify a timeout of 10 seconds.
   """
-  @spec call_function(pid(), String.t() | atom(), list(number()), pos_integer()) ::
+  @spec call_function(GenServer.server(), String.t() | atom(), list(number()), pos_integer()) ::
           {:ok, list(number())} | {:error, any()}
   def call_function(pid, name, params, timeout \\ 5000) do
     GenServer.call(pid, {:call_function, Wasmex.Utils.stringify(name), params}, timeout)
@@ -415,7 +415,7 @@ defmodule Wasmex do
       iex> {:ok, pid} = Wasmex.start_link(%{bytes: File.read!(TestHelper.wasm_test_file_path())})
       iex> {:ok, %Wasmex.Memory{}} = Wasmex.memory(pid)
   """
-  @spec memory(pid()) :: {:ok, Wasmex.Memory.t()} | {:error, any()}
+  @spec memory(GenServer.server()) :: {:ok, Wasmex.Memory.t()} | {:error, any()}
   def memory(pid), do: GenServer.call(pid, {:memory})
 
   @doc ~S"""
@@ -426,7 +426,7 @@ defmodule Wasmex do
       iex> {:ok, pid} = Wasmex.start_link(%{bytes: File.read!(TestHelper.wasm_test_file_path())})
       iex> {:ok, %Wasmex.StoreOrCaller{}} = Wasmex.store(pid)
   """
-  @spec store(pid()) :: {:ok, Wasmex.StoreOrCaller.t()} | {:error, any()}
+  @spec store(GenServer.server()) :: {:ok, Wasmex.StoreOrCaller.t()} | {:error, any()}
   def store(pid), do: GenServer.call(pid, {:store})
 
   @doc ~S"""
@@ -437,7 +437,7 @@ defmodule Wasmex do
       iex> {:ok, pid} = Wasmex.start_link(%{bytes: File.read!(TestHelper.wasm_test_file_path())})
       iex> {:ok, %Wasmex.Module{}} = Wasmex.module(pid)
   """
-  @spec module(pid()) :: {:ok, Wasmex.Module.t()} | {:error, any()}
+  @spec module(GenServer.server()) :: {:ok, Wasmex.Module.t()} | {:error, any()}
   def module(pid), do: GenServer.call(pid, {:module})
 
   @doc ~S"""
@@ -448,7 +448,7 @@ defmodule Wasmex do
       iex> {:ok, pid} = Wasmex.start_link(%{bytes: File.read!(TestHelper.wasm_test_file_path())})
       iex> {:ok, %Wasmex.Instance{}} = Wasmex.instance(pid)
   """
-  @spec instance(pid()) :: {:ok, Wasmex.Instance.t()} | {:error, any()}
+  @spec instance(GenServer.server()) :: {:ok, Wasmex.Instance.t()} | {:error, any()}
   def instance(pid), do: GenServer.call(pid, {:instance})
 
   # Server

--- a/lib/wasmex/components.ex
+++ b/lib/wasmex/components.ex
@@ -247,7 +247,7 @@ defmodule Wasmex.Components do
 
   @type function_name_or_path :: String.t() | list(String.t()) | tuple() | atom() | list(atom())
 
-  @spec call_function(GenServer.server(), function_name_or_path(), list(number()), pos_integer()) ::
+  @spec call_function(GenServer.server(), function_name_or_path(), list(any()), pos_integer()) ::
           {:ok, list(number())} | {:error, any()}
   def call_function(pid, name_or_path, params, timeout \\ 5000) do
     GenServer.call(pid, {:call_function, name_or_path, params}, timeout)

--- a/lib/wasmex/components.ex
+++ b/lib/wasmex/components.ex
@@ -247,7 +247,7 @@ defmodule Wasmex.Components do
 
   @type function_name_or_path :: String.t() | list(String.t()) | tuple() | atom() | list(atom())
 
-  @spec call_function(pid(), function_name_or_path(), list(number()), pos_integer()) ::
+  @spec call_function(GenServer.server(), function_name_or_path(), list(number()), pos_integer()) ::
           {:ok, list(number())} | {:error, any()}
   def call_function(pid, name_or_path, params, timeout \\ 5000) do
     GenServer.call(pid, {:call_function, name_or_path, params}, timeout)

--- a/lib/wasmex/components.ex
+++ b/lib/wasmex/components.ex
@@ -248,7 +248,7 @@ defmodule Wasmex.Components do
   @type function_name_or_path :: String.t() | list(String.t()) | tuple() | atom() | list(atom())
 
   @spec call_function(GenServer.server(), function_name_or_path(), list(any()), pos_integer()) ::
-          {:ok, list(number())} | {:error, any()}
+          {:ok, any()} | {:error, any()}
   def call_function(pid, name_or_path, params, timeout \\ 5000) do
     GenServer.call(pid, {:call_function, name_or_path, params}, timeout)
   end


### PR DESCRIPTION
`GenServer.call/3` is able to accept a few types other than `pid()` as it's first argument. Notably, it can accept an atom, which is what you would want to pass if you wanted to call a process by it's [registered name](https://elixir.hexdocs.pm/1.20.2/GenServer.html#module-name-registration).

This PR changes the typespecs for all functions passing a pid to `GenServer.call/3` to accept `GenServer.server()` (ie. the same type as `GenServer.call/3`'s first argument) instead of `pid()`, allowing processes to be called by their registered name without violating the typespec.

`Wasmex.Components.call_function/4` was also modified to accept a list of arbitrary `any()`s instead of just `number()` and return `any()` instead of `list(number())`, since the component model allows for a much wider range of types to be passed between WebAssembly function calls than just numbers.