### PR TITLE
Run Wasmtime stores on async executors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,27 @@ Types of changes
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased]
+## [0.15.0 - YYYY-MM-DD]
 
 ### Added
 
 - Added support for registering core Wasmex GenServers with the `:name` option.
 
+### Changed
+
+- Raised the minimum Elixir version to 1.18 and updated the supported compatibility matrix to Elixir 1.18–1.20 and Erlang/OTP 27–29.
+- Updated Wasmtime from 39.0.1 to 47.0.2, Rustler to 0.38.0, rustler_precompiled to 0.9.0, and refreshed the remaining Rust and Elixir dependencies.
+- Migrated the WASI Preview 1, WASI Preview 2, and WASI HTTP integrations to the Wasmtime 47 APIs.
+- Moved core and component instantiation, function execution, WASI, and WASI HTTP workloads to Wasmtime's asynchronous APIs. Each Store now runs on a bounded, single-owner Tokio executor that preserves operation ordering and provides backpressure without blocking executor threads.
+- Added cooperative epoch-based yielding for long-running WebAssembly calls and cancellation tied to call timeouts, allowing a Store to process subsequent work after a timed-out call.
+- Reworked imported-function callbacks to await asynchronous replies while servicing scoped Caller operations, including memory, fuel, globals, export lookup, nested calls, and instance creation.
+
 ### Fixed
 
 - Corrected public typespecs to accept registered GenServer names and to reflect the full range of WebAssembly component parameter and return values. Thanks @Sorixelle (#971)
+- Propagate errors encountered while registering WASI and WASI HTTP component interfaces instead of silently ignoring them.
+- Removed the unsafe global storage and lifetime extension previously used for callback-scoped Callers.
+- Component callback failures and result-conversion errors now release the waiting Wasmtime call instead of potentially leaving it blocked indefinitely.
 
 ## [0.14.0 - 2025-12-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,15 @@ Types of changes
 - Updated Wasmtime from 39.0.1 to 47.0.2, Rustler to 0.38.0, rustler_precompiled to 0.9.0, and refreshed the remaining Rust and Elixir dependencies.
 - Migrated the WASI Preview 1, WASI Preview 2, and WASI HTTP integrations to the Wasmtime 47 APIs.
 - Moved core and component instantiation, function execution, WASI, and WASI HTTP workloads to Wasmtime's asynchronous APIs. Each Store now runs on a bounded, single-owner Tokio executor that preserves operation ordering and provides backpressure without blocking executor threads.
-- Added cooperative epoch-based yielding for long-running WebAssembly calls and cancellation tied to call timeouts, allowing a Store to process subsequent work after a timed-out call.
+- Added cooperative epoch-based yielding for core WebAssembly calls. Timed-out core calls are interrupted so their Store can process subsequent work.
+- Component calls that outlive their caller's timeout now finish in the background and discard their late result, preserving the Wasmtime component instance for subsequent calls.
 - Reworked imported-function callbacks to await asynchronous replies while servicing scoped Caller operations, including memory, fuel, globals, export lookup, nested calls, and instance creation.
 
 ### Fixed
 
 - Corrected public typespecs to accept registered GenServer names and to reflect the full range of WebAssembly component parameter and return values. Thanks @Sorixelle (#971)
 - Propagate errors encountered while registering WASI and WASI HTTP component interfaces instead of silently ignoring them.
-- Removed the unsafe global storage and lifetime extension previously used for callback-scoped Callers.
-- Component callback failures and result-conversion errors now release the waiting Wasmtime call instead of potentially leaving it blocked indefinitely.
+- Callback failures, result-conversion errors, and replies that arrive after a caller timeout now release the waiting Wasmtime call without terminating the Wasmex server.
 
 ## [0.14.0 - 2025-12-16]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img width="300" src="./logo.svg" alt="Wasmex logo">
 </p>
 <p align="center">
-  <a href="https://github.com/tessi/wasmex/blob/master/LICENSE">
+  <a href="https://github.com/tessi/wasmex/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/tessi/wasmex.svg" alt="License">
   </a>
   <a href="https://github.com/tessi/wasmex/actions/workflows/elixir-ci.yml">
@@ -32,7 +32,7 @@ end
 
 ## Example
 
-There is a toy Wasm program in `test/wasm_test/src/lib.rs`, written in Rust (but could potentially be any other language that compiles to WebAssembly).
+There is a toy Wasm program in `test/fixture_projects/wasm_test/src/lib.rs`, written in Rust (but could potentially be any other language that compiles to WebAssembly).
 It defines many functions we use for end-to-end testing, but also serves as example code. For example:
 
 ```rust
@@ -42,12 +42,16 @@ pub extern fn sum(x: i32, y: i32) -> i32 {
 }
 ```
 
-Once this program compiled to WebAssembly (which we do every time when running tests), we end up with a `wasmex_test.wasm` binary file.
+Once this program is compiled to WebAssembly (which happens whenever the tests run),
+we get a `wasmex_test.wasm` binary file.
 
 This Wasm file can be executed in Elixir:
 
 ```elixir
-bytes = File.read!("wasmex_test.wasm")
+bytes =
+  File.read!(
+    "test/fixture_projects/wasm_test/target/wasm32-unknown-unknown/debug/wasmex_test.wasm"
+  )
 {:ok, pid} = Wasmex.start_link(%{bytes: bytes}) # starts a GenServer running a Wasm instance
 {:ok, [42]} == Wasmex.call_function(pid, "sum", [50, -8])
 ```
@@ -107,7 +111,7 @@ In addition to tests, we expect the formatters and linters (`cargo fmt`, `cargo 
 
 ## License
 
-The entire project is under the MIT License. Please read [the`LICENSE` file](https://github.com/tessi/wasmex/blob/master/LICENSE).
+The entire project is under the MIT License. Please read [the `LICENSE` file](https://github.com/tessi/wasmex/blob/main/LICENSE).
 
 ### Licensing
 

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -90,8 +90,8 @@ defmodule Wasmex do
 
   The `caller` MUST be used instead of a `store` in Wasmex API functions.
   Wasmex might deadlock if the `store` is used instead of the `caller`
-  (because running the Wasm instance holds a Mutex lock on the `store` so
-  we cannot use that store again during the execution of an imported function).
+  (because a Store processes one operation at a time, and the current operation
+  cannot finish until the imported function returns).
   The caller, however, MUST NOT be used outside of the imported functions scope.
 
   All other params are regular parameters as specified by the parameter type list.
@@ -414,7 +414,11 @@ defmodule Wasmex do
   @spec call_function(GenServer.server(), String.t() | atom(), list(number()), pos_integer()) ::
           {:ok, list(number())} | {:error, any()}
   def call_function(pid, name, params, timeout \\ 5000) do
-    GenServer.call(pid, {:call_function, Wasmex.Utils.stringify(name), params}, timeout)
+    GenServer.call(
+      pid,
+      {:call_function, Wasmex.Utils.stringify(name), params, native_timeout(timeout)},
+      timeout
+    )
   end
 
   @doc ~S"""
@@ -522,11 +526,11 @@ defmodule Wasmex do
 
   @impl true
   def handle_call(
-        {:call_function, name, params},
+        {:call_function, name, params, timeout},
         from,
         %{store: store, instance: instance} = state
       ) do
-    :ok = Wasmex.Instance.call_exported_function(store, instance, name, params, from)
+    :ok = Wasmex.Instance.call_exported_function(store, instance, name, params, from, timeout)
     {:noreply, state}
   end
 
@@ -570,4 +574,7 @@ defmodule Wasmex do
     :ok = Wasmex.Native.instance_receive_callback_result(token, success, results)
     {:noreply, state}
   end
+
+  defp native_timeout(:infinity), do: nil
+  defp native_timeout(timeout), do: timeout
 end

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -167,7 +167,7 @@ defmodule Wasmex do
       ...>   wasi_snapshot_preview1: %{
       ...>     random_get: {:fn, [:i32, :i32], [:i32],
       ...>                  fn %{memory: memory, caller: caller}, address, size ->
-      ...>                    Enum.each(0..size, fn index ->
+      ...>                    Enum.each(0..(size - 1)//1, fn index ->
       ...>                      Wasmex.Memory.set_byte(caller, memory, address + index, 0)
       ...>                    end)
       ...>                    # We chose `4` as the random number with a fair dice roll
@@ -177,7 +177,7 @@ defmodule Wasmex do
       ...>                 }
       ...>   }
       ...> }
-      iex> {:ok, _pid} = Wasmex.start_link(%{bytes: "(module)", imports: imports})
+      iex> {:ok, _pid} = Wasmex.start_link(%{bytes: "(module)", imports: imports, wasi: true})
 
   In the example above, we overwrite the `random_get` function which is (as all other WASI functions)
   implemented in Rust. This way our Elixir implementation of `random_get` is used instead of the
@@ -399,7 +399,8 @@ defmodule Wasmex do
   ## Specifying a timeout
 
   The default timeout for `call_function` is 5 seconds, or 5000 milliseconds.
-  When calling a long-running function, you can specify a timeout value (in milliseconds) for this call.
+  When calling a long-running function, you can specify a timeout in milliseconds,
+  or use `:infinity`.
 
       iex> wat = "(module
       ...>          (func $helloWorld (result i32) (i32.const 42))
@@ -409,14 +410,17 @@ defmodule Wasmex do
       iex> Wasmex.call_function(pid, "hello_world", [], 10_000)
       {:ok, [42]}
 
-  In the example above, we specify a timeout of 10 seconds.
+  In the example above, we specify a timeout of 10 seconds. If a call times out,
+  Wasmex interrupts its WebAssembly execution and keeps the Store available for
+  subsequent calls.
   """
-  @spec call_function(GenServer.server(), String.t() | atom(), list(number()), pos_integer()) ::
+  @spec call_function(GenServer.server(), String.t() | atom(), list(number()), timeout()) ::
           {:ok, list(number())} | {:error, any()}
   def call_function(pid, name, params, timeout \\ 5000) do
     GenServer.call(
       pid,
-      {:call_function, Wasmex.Utils.stringify(name), params, native_timeout(timeout)},
+      {:call_function, Wasmex.Utils.stringify(name), params,
+       Wasmex.Utils.native_timeout(timeout)},
       timeout
     )
   end
@@ -568,13 +572,12 @@ defmodule Wasmex do
 
         {true, results}
       rescue
-        e in RuntimeError -> {false, [e.message]}
+        exception -> {false, [Exception.message(exception)]}
+      catch
+        kind, reason -> {false, [Exception.format_banner(kind, reason)]}
       end
 
     :ok = Wasmex.Native.instance_receive_callback_result(token, success, results)
     {:noreply, state}
   end
-
-  defp native_timeout(:infinity), do: nil
-  defp native_timeout(timeout), do: timeout
 end

--- a/lib/wasmex/components.ex
+++ b/lib/wasmex/components.ex
@@ -250,7 +250,7 @@ defmodule Wasmex.Components do
   @spec call_function(GenServer.server(), function_name_or_path(), list(any()), pos_integer()) ::
           {:ok, any()} | {:error, any()}
   def call_function(pid, name_or_path, params, timeout \\ 5000) do
-    GenServer.call(pid, {:call_function, name_or_path, params}, timeout)
+    GenServer.call(pid, {:call_function, name_or_path, params, native_timeout(timeout)}, timeout)
   end
 
   @impl true
@@ -266,11 +266,11 @@ defmodule Wasmex.Components do
 
   @impl true
   def handle_call(
-        {:call_function, name, params},
+        {:call_function, name, params, timeout},
         from,
         %{instance: instance} = state
       ) do
-    :ok = Wasmex.Components.Instance.call_function(instance, name, params, from)
+    :ok = Wasmex.Components.Instance.call_function(instance, name, params, from, timeout)
     {:noreply, state}
   end
 
@@ -292,4 +292,7 @@ defmodule Wasmex.Components do
     :ok = Wasmex.Native.component_receive_callback_result(component.resource, token, true, result)
     {:noreply, state}
   end
+
+  defp native_timeout(:infinity), do: nil
+  defp native_timeout(timeout), do: timeout
 end

--- a/lib/wasmex/components.ex
+++ b/lib/wasmex/components.ex
@@ -245,12 +245,30 @@ defmodule Wasmex.Components do
     end
   end
 
-  @type function_name_or_path :: String.t() | list(String.t()) | tuple() | atom() | list(atom())
+  @type function_name_or_path :: String.t() | atom() | [String.t() | atom()] | tuple()
 
-  @spec call_function(GenServer.server(), function_name_or_path(), list(any()), pos_integer()) ::
+  @doc """
+  Calls an exported component function.
+
+  `name_or_path` may be a function name or a path identifying an exported
+  interface function. Parameters and results use the Elixir representations
+  described in the component interface type documentation above.
+
+  The default timeout is 5 seconds. A timeout exits the calling process unless
+  it traps exits, just like `GenServer.call/3`. Wasmtime component calls cannot
+  currently be cancelled without invalidating the component instance, so a
+  timed-out call continues in the background. Its late result is discarded and
+  later operations on the same Store wait for it to finish. Use `:infinity` for
+  calls whose duration is intentionally unbounded.
+  """
+  @spec call_function(GenServer.server(), function_name_or_path(), list(any()), timeout()) ::
           {:ok, any()} | {:error, any()}
   def call_function(pid, name_or_path, params, timeout \\ 5000) do
-    GenServer.call(pid, {:call_function, name_or_path, params, native_timeout(timeout)}, timeout)
+    GenServer.call(
+      pid,
+      {:call_function, name_or_path, params, Wasmex.Utils.native_timeout(timeout)},
+      timeout
+    )
   end
 
   @impl true
@@ -288,11 +306,23 @@ defmodule Wasmex.Components do
         Map.get(imports, name)
       end
 
-    result = apply(function, params)
-    :ok = Wasmex.Native.component_receive_callback_result(component.resource, token, true, result)
+    {success, result} =
+      try do
+        {true, apply(function, params)}
+      rescue
+        exception -> {false, Exception.message(exception)}
+      catch
+        kind, reason -> {false, Exception.format_banner(kind, reason)}
+      end
+
+    :ok =
+      Wasmex.Native.component_receive_callback_result(
+        component.resource,
+        token,
+        success,
+        result
+      )
+
     {:noreply, state}
   end
-
-  defp native_timeout(:infinity), do: nil
-  defp native_timeout(timeout), do: timeout
 end

--- a/lib/wasmex/components/component_instance.ex
+++ b/lib/wasmex/components/component_instance.ex
@@ -1,7 +1,16 @@
 defmodule Wasmex.Components.Instance do
   @moduledoc """
-  The component model equivalent to `Wasmex.Instance`
+  The component model equivalent to `Wasmex.Instance`.
+
+  Most applications should use `Wasmex.Components` or
+  `Wasmex.Components.ComponentServer` instead.
   """
+  @type t :: %__MODULE__{
+          store_resource: binary(),
+          instance_resource: binary(),
+          reference: reference()
+        }
+
   defstruct store_resource: nil,
             instance_resource: nil,
             # The actual NIF store resource.
@@ -39,12 +48,28 @@ defmodule Wasmex.Components.Instance do
     end
   end
 
+  @doc """
+  Schedules a call to an exported component function.
+
+  The `from` argument must be the caller tuple passed to
+  `c:GenServer.handle_call/3`. The result is sent to that caller after execution.
+  If `timeout` expires first, the component call continues to completion because
+  Wasmtime cannot cancel it without invalidating the instance; the late result
+  is discarded.
+  """
+  @spec call_function(
+          __MODULE__.t(),
+          Wasmex.Components.function_name_or_path(),
+          list(),
+          GenServer.from(),
+          non_neg_integer() | nil
+        ) :: :ok
   def call_function(
         %__MODULE__{store_resource: store_resource, instance_resource: instance_resource},
         function_or_path,
         args,
         from,
-        timeout
+        timeout \\ nil
       ) do
     function_path = parse_function_path(function_or_path)
 

--- a/lib/wasmex/components/component_instance.ex
+++ b/lib/wasmex/components/component_instance.ex
@@ -23,11 +23,17 @@ defmodule Wasmex.Components.Instance do
     %{resource: store_or_caller_resource} = store_or_caller
     %{resource: component_resource} = component
 
-    case Wasmex.Native.component_instance_new(
-           store_or_caller_resource,
-           component_resource,
-           imports
-         ) do
+    result =
+      Wasmex.Utils.native_request(fn from ->
+        Wasmex.Native.component_instance_new(
+          store_or_caller_resource,
+          component_resource,
+          imports,
+          from
+        )
+      end)
+
+    case result do
       {:error, err} -> {:error, err}
       resource -> {:ok, __wrap_resource__(store_or_caller_resource, resource)}
     end
@@ -37,7 +43,8 @@ defmodule Wasmex.Components.Instance do
         %__MODULE__{store_resource: store_resource, instance_resource: instance_resource},
         function_or_path,
         args,
-        from
+        from,
+        timeout
       ) do
     function_path = parse_function_path(function_or_path)
 
@@ -46,7 +53,8 @@ defmodule Wasmex.Components.Instance do
       instance_resource,
       function_path,
       args,
-      from
+      from,
+      timeout
     )
   end
 

--- a/lib/wasmex/components/component_server.ex
+++ b/lib/wasmex/components/component_server.ex
@@ -15,7 +15,7 @@ defmodule Wasmex.Components.ComponentServer do
   Given a WIT file `greeter.wit` with the following content:
 
   ```wit
-  package example:greeter
+  package example:greeter;
 
   world greeter {
     export greet: func(who: string) -> string;
@@ -39,8 +39,8 @@ defmodule Wasmex.Components.ComponentServer do
   iex> {:ok, pid} = MyApp.Greeter.start_link(path: "path/to/greeter.wasm")
 
   # Generated function wrappers:
-  iex> MyApp.Greeter.greet(pid, "World")  # Returns: "Hello, World!"
-  iex> MyApp.Greeter.multi_greet(pid, "World", 2) # Returns: ["Hello, World!", "Hello, World!"]
+  iex> MyApp.Greeter.greet(pid, "World")  # Returns: {:ok, "Hello, World!"}
+  iex> MyApp.Greeter.multi_greet(pid, "World", 2) # Returns: {:ok, ["Hello, World!", "Hello, World!"]}
   ```
 
   ## Imports Example
@@ -49,13 +49,13 @@ defmodule Wasmex.Components.ComponentServer do
   For example, given a WIT file `logger.wit`:
 
   ```wit
-  package example:logger
+  package example:logger;
 
   world logger {
-    import log: func(message: string)
-    import get-timestamp: func() -> u64
+    import log: func(message: string);
+    import get-timestamp: func() -> u64;
 
-    export log-with-timestamp: func(message: string)
+    export log-with-timestamp: func(message: string);
   }
   ```
 
@@ -66,31 +66,30 @@ defmodule Wasmex.Components.ComponentServer do
     use Wasmex.Components.ComponentServer,
       wit: "path/to/logger.wit",
       imports: %{
-        "log" => fn message ->
+        "log" => {:fn, fn message ->
           IO.puts(message)
-          :ok
-        end,
-        "get-timestamp" => fn ->
+        end},
+        "get-timestamp" => {:fn, fn ->
           System.system_time(:second)
-        end
+        end}
       }
   end
   ```
 
   # Usage:
   ```elixir
-  iex> {:ok, pid} = MyApp.Logger.start_link(wasm: "path/to/logger.wasm")
+  iex> {:ok, pid} = MyApp.Logger.start_link(path: "path/to/logger.wasm")
   iex> MyApp.Logger.log_with_timestamp(pid, "Hello from Wasm!")
   ```
 
-  The import functions should return the correct types as defined in the WIT file. Incorrect types will likely
-  cause a crash, or possibly a NIF panic.
+  Import functions must return the types defined in the WIT file. An incompatible
+  return value traps the component call and is returned as an error.
 
   ## Options
 
   * `:wit` - Path to the WIT file defining the component's interface
-  * `:convert_field_names` - All function calls will for all arugments
-  recursively convert any map field names from under_score case to kebab-case
+  * `:convert_field_names` - All function calls recursively convert map field names
+  in arguments from underscore case to kebab-case
   and vice versa for return values. Defaults to true.
   * `:imports` - A map of import function implementations that the component requires, where each key
     is the function name as defined in the WIT file and the value is the implementing function

--- a/lib/wasmex/engine.ex
+++ b/lib/wasmex/engine.ex
@@ -8,7 +8,7 @@ defmodule Wasmex.Engine do
   program.
 
   You can create an engine with default configuration settings using
-  `EngineConfig::default()`. Be sure to consult the documentation of
+  `Wasmex.Engine.default/0`. Be sure to consult the documentation of
   `Wasmex.EngineConfig` for default settings.
 
   ## Example

--- a/lib/wasmex/instance.ex
+++ b/lib/wasmex/instance.ex
@@ -85,7 +85,18 @@ defmodule Wasmex.Instance do
         %{name: name, module_resource: module.resource}
       end)
 
-    case Wasmex.Native.instance_new(store_or_caller_resource, module_resource, imports, links) do
+    result =
+      Wasmex.Utils.native_request(fn from ->
+        Wasmex.Native.instance_new(
+          store_or_caller_resource,
+          module_resource,
+          imports,
+          links,
+          from
+        )
+      end)
+
+    case result do
       {:error, err} -> {:error, err}
       resource -> {:ok, __wrap_resource__(resource)}
     end
@@ -109,11 +120,14 @@ defmodule Wasmex.Instance do
     %Wasmex.StoreOrCaller{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: instance_resource} = instance
 
-    Wasmex.Native.instance_function_export_exists(
-      store_or_caller_resource,
-      instance_resource,
-      name
-    )
+    Wasmex.Utils.native_request(fn from ->
+      Wasmex.Native.instance_function_export_exists(
+        store_or_caller_resource,
+        instance_resource,
+        name,
+        from
+      )
+    end)
   end
 
   @doc ~S"""
@@ -128,8 +142,8 @@ defmodule Wasmex.Instance do
 
   ## Implementation Details
 
-  Behind the scenes the wasmex NIF will spawn a Tokio task (green thread) to execute the Wasm function.
-  The Tokio runtime is instantiated with `number of CPU cores` native OS worker threads.
+  Behind the scenes, the NIF submits the call to the Store's bounded executor.
+  Each Store processes one operation at a time and yields cooperatively while WebAssembly runs.
 
   The `from` argument is expected to be as given by `c:GenServer.handle_call/3`.
   The NIF uses this `from` tuple to send a message with the result of this Wasm function call.
@@ -147,10 +161,11 @@ defmodule Wasmex.Instance do
           __MODULE__.t(),
           binary(),
           [any()],
-          GenServer.from()
+          GenServer.from(),
+          non_neg_integer() | nil
         ) ::
           :ok | {:error, binary()}
-  def call_exported_function(store_or_caller, instance, name, params, from)
+  def call_exported_function(store_or_caller, instance, name, params, from, timeout \\ nil)
       when is_binary(name) do
     %{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: instance_resource} = instance
@@ -160,7 +175,8 @@ defmodule Wasmex.Instance do
       instance_resource,
       name,
       params,
-      from
+      from,
+      timeout
     )
   end
 
@@ -202,11 +218,14 @@ defmodule Wasmex.Instance do
     %{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: instance_resource} = instance
 
-    Wasmex.Native.instance_get_global_value(
-      store_or_caller_resource,
-      instance_resource,
-      global_name
-    )
+    Wasmex.Utils.native_request(fn from ->
+      Wasmex.Native.instance_get_global_value(
+        store_or_caller_resource,
+        instance_resource,
+        global_name,
+        from
+      )
+    end)
     |> case do
       {:error, _reason} = term -> term
       result when is_number(result) -> {:ok, result}
@@ -236,12 +255,15 @@ defmodule Wasmex.Instance do
     %{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: instance_resource} = instance
 
-    Wasmex.Native.instance_set_global_value(
-      store_or_caller_resource,
-      instance_resource,
-      global_name,
-      new_value
-    )
+    Wasmex.Utils.native_request(fn from ->
+      Wasmex.Native.instance_set_global_value(
+        store_or_caller_resource,
+        instance_resource,
+        global_name,
+        new_value,
+        from
+      )
+    end)
     |> case do
       {} -> :ok
       {:error, _reason} = term -> term

--- a/lib/wasmex/instance.ex
+++ b/lib/wasmex/instance.ex
@@ -144,9 +144,12 @@ defmodule Wasmex.Instance do
 
   Behind the scenes, the NIF submits the call to the Store's bounded executor.
   Each Store processes one operation at a time and yields cooperatively while WebAssembly runs.
+  If `timeout` is set and the deadline is reached, Wasmex interrupts the WebAssembly call,
+  discards its result, and releases the Store for subsequent operations.
 
   The `from` argument is expected to be as given by `c:GenServer.handle_call/3`.
   The NIF uses this `from` tuple to send a message with the result of this Wasm function call.
+  If the receiving process is no longer waiting, the result is discarded.
 
   ## Function parameters
 

--- a/lib/wasmex/memory.ex
+++ b/lib/wasmex/memory.ex
@@ -51,7 +51,12 @@ defmodule Wasmex.Memory do
     %{resource: store_or_caller_resource} = store_or_caller
     %Wasmex.Instance{resource: instance_resource} = instance
 
-    case Wasmex.Native.memory_from_instance(store_or_caller_resource, instance_resource) do
+    result =
+      Wasmex.Utils.native_request(fn from ->
+        Wasmex.Native.memory_from_instance(store_or_caller_resource, instance_resource, from)
+      end)
+
+    case result do
       {:error, err} -> {:error, err}
       resource -> {:ok, __wrap_resource__(resource)}
     end
@@ -74,7 +79,10 @@ defmodule Wasmex.Memory do
   def size(store_or_caller, memory) do
     %Wasmex.StoreOrCaller{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: memory_resource} = memory
-    Wasmex.Native.memory_size(store_or_caller_resource, memory_resource)
+
+    Wasmex.Utils.native_request(fn from ->
+      Wasmex.Native.memory_size(store_or_caller_resource, memory_resource, from)
+    end)
   end
 
   @doc ~S"""
@@ -97,7 +105,10 @@ defmodule Wasmex.Memory do
   def grow(store_or_caller, memory, pages) do
     %Wasmex.StoreOrCaller{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: memory_resource} = memory
-    Wasmex.Native.memory_grow(store_or_caller_resource, memory_resource, pages)
+
+    Wasmex.Utils.native_request(fn from ->
+      Wasmex.Native.memory_grow(store_or_caller_resource, memory_resource, pages, from)
+    end)
   end
 
   @doc ~S"""
@@ -120,7 +131,9 @@ defmodule Wasmex.Memory do
     %{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: memory_resource} = memory
 
-    Wasmex.Native.memory_get_byte(store_or_caller_resource, memory_resource, index)
+    Wasmex.Utils.native_request(fn from ->
+      Wasmex.Native.memory_get_byte(store_or_caller_resource, memory_resource, index, from)
+    end)
   end
 
   @doc ~S"""
@@ -143,7 +156,15 @@ defmodule Wasmex.Memory do
     %{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: memory_resource} = memory
 
-    Wasmex.Native.memory_set_byte(store_or_caller_resource, memory_resource, index, value)
+    Wasmex.Utils.native_request(fn from ->
+      Wasmex.Native.memory_set_byte(
+        store_or_caller_resource,
+        memory_resource,
+        index,
+        value,
+        from
+      )
+    end)
   end
 
   @doc ~S"""
@@ -171,12 +192,15 @@ defmodule Wasmex.Memory do
     %Wasmex.StoreOrCaller{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: memory_resource} = memory
 
-    Wasmex.Native.memory_write_binary(
-      store_or_caller_resource,
-      memory_resource,
-      index,
-      binary
-    )
+    Wasmex.Utils.native_request(fn from ->
+      Wasmex.Native.memory_write_binary(
+        store_or_caller_resource,
+        memory_resource,
+        index,
+        binary,
+        from
+      )
+    end)
   end
 
   @doc ~S"""
@@ -209,12 +233,15 @@ defmodule Wasmex.Memory do
     %Wasmex.StoreOrCaller{resource: store_or_caller_resource} = store_or_caller
     %__MODULE__{resource: memory_resource} = memory
 
-    Wasmex.Native.memory_read_binary(
-      store_or_caller_resource,
-      memory_resource,
-      index,
-      length
-    )
+    Wasmex.Utils.native_request(fn from ->
+      Wasmex.Native.memory_read_binary(
+        store_or_caller_resource,
+        memory_resource,
+        index,
+        length,
+        from
+      )
+    end)
   end
 
   @doc ~S"""

--- a/lib/wasmex/module.ex
+++ b/lib/wasmex/module.ex
@@ -178,10 +178,10 @@ defmodule Wasmex.Module do
 
   @doc ~S"""
   Deserializes an in-memory compiled module previously created with
-  `Wasmex.Module.serialize/1` or `Wasmex.Engine::precompile_module/2`.
+  `Wasmex.Module.serialize/1` or `Wasmex.Engine.precompile_module/2`.
 
   This function will deserialize the binary blobs emitted by
-  `Wasmex.Module.serialize/1` and `Wasmex.Engine::precompile_module/2`
+  `Wasmex.Module.serialize/1` and `Wasmex.Engine.precompile_module/2`
   back into an in-memory `Wasmex.Module` that's ready to be instantiated.
 
   # Unsafety
@@ -199,7 +199,7 @@ defmodule Wasmex.Module do
 
   For these reasons this function is `unsafe`. This function is only
   designed to receive the previous input from `Wasmex.Module.serialize/1`
-  and `Wasmex.Engine::precompile_module/2`. If the exact output of those
+  and `Wasmex.Engine.precompile_module/2`. If the exact output of those
   functions (unmodified) is passed to this function then calls to this
   function can be considered safe. It is the caller's responsibility to
   provide the guarantee that only previously-serialized bytes are being

--- a/lib/wasmex/native.ex
+++ b/lib/wasmex/native.ex
@@ -36,12 +36,14 @@ defmodule Wasmex.Native do
   def module_serialize(_module_resource), do: error()
   def module_unsafe_deserialize(_binary, _engine_resource), do: error()
 
-  def instance_new(_store_or_caller_resource, _module_resource, _imports, _links), do: error()
+  def instance_new(_store_or_caller_resource, _module_resource, _imports, _links, _from),
+    do: error()
 
   def instance_function_export_exists(
         _store_or_caller_resource,
         _instance_resource,
-        _function_name
+        _function_name,
+        _from
       ),
       do: error()
 
@@ -52,28 +54,44 @@ defmodule Wasmex.Native do
         _instance_resource,
         _function_name,
         _params,
-        _from
+        _from,
+        _timeout
       ),
       do: error()
 
-  def instance_get_global_value(_store_or_caller_resource, _instance_resource, _global_name),
-    do: error()
+  def instance_get_global_value(
+        _store_or_caller_resource,
+        _instance_resource,
+        _global_name,
+        _from
+      ),
+      do: error()
 
   def instance_set_global_value(
         _store_or_caller_resource,
         _instance_resource,
         _global_name,
-        _new_value
+        _new_value,
+        _from
       ),
       do: error()
 
-  def memory_from_instance(_store_resource, _memory_resource), do: error()
-  def memory_size(_store_resource, _memory_resource), do: error()
-  def memory_grow(_store_resource, _memory_resource, _pages), do: error()
-  def memory_get_byte(_store_or_caller_resource, _memory_resource, _index), do: error()
-  def memory_set_byte(_store_or_caller_resource, _memory_resource, _index, _value), do: error()
-  def memory_read_binary(_store_resource, _memory_resource, _index, _length), do: error()
-  def memory_write_binary(_store_resource, _memory_resource, _index, _binary), do: error()
+  def memory_from_instance(_store_resource, _memory_resource, _from), do: error()
+  def memory_size(_store_resource, _memory_resource, _from), do: error()
+  def memory_grow(_store_resource, _memory_resource, _pages, _from), do: error()
+  def memory_get_byte(_store_or_caller_resource, _memory_resource, _index, _from), do: error()
+
+  def memory_set_byte(
+        _store_or_caller_resource,
+        _memory_resource,
+        _index,
+        _value,
+        _from
+      ),
+      do: error()
+
+  def memory_read_binary(_store_resource, _memory_resource, _index, _length, _from), do: error()
+  def memory_write_binary(_store_resource, _memory_resource, _index, _binary, _from), do: error()
 
   def pipe_new(), do: error()
   def pipe_size(_pipe_resource), do: error()
@@ -87,12 +105,21 @@ defmodule Wasmex.Native do
   def component_store_new(_store_limits, _engine_resource), do: error()
   def component_store_new_wasi(_wasi_options, _store_limits, _engine_resource), do: error()
 
-  def store_or_caller_get_fuel(_store_or_caller_resource), do: error()
-  def store_or_caller_set_fuel(_store_or_caller_resource, _fuel), do: error()
+  def store_or_caller_get_fuel(_store_or_caller_resource, _from), do: error()
+  def store_or_caller_set_fuel(_store_or_caller_resource, _fuel, _from), do: error()
 
   def component_new(_store, _component_bytes), do: error()
-  def component_instance_new(_store, _component, _imports), do: error()
-  def component_call_function(_store, _instance, _function_name_path, _params, _from), do: error()
+  def component_instance_new(_store, _component, _imports, _from), do: error()
+
+  def component_call_function(
+        _store,
+        _instance,
+        _function_name_path,
+        _params,
+        _from,
+        _timeout
+      ),
+      do: error()
 
   def component_receive_callback_result(_component_resource, _token, _success, _result),
     do: error()

--- a/lib/wasmex/pipe.ex
+++ b/lib/wasmex/pipe.ex
@@ -52,7 +52,7 @@ defmodule Wasmex.Pipe do
 
   ## Example
 
-      iex> {:ok, %Pipe{}} = Wasmex.Pipe.new()
+      iex> {:ok, %Wasmex.Pipe{}} = Wasmex.Pipe.new()
   """
   @spec new() :: {:error, reason :: binary()} | {:ok, __MODULE__.t()}
   def new() do

--- a/lib/wasmex/store.ex
+++ b/lib/wasmex/store.ex
@@ -14,6 +14,11 @@ defmodule Wasmex.Store do
   unsuitable for creating an unbounded number of instances in it because Store will
   never release this memory. It’s recommended to have a Store correspond roughly
   to the lifetime of a “main instance”.
+
+  Store operations are submitted to a bounded asynchronous executor and processed
+  one at a time in submission order. WebAssembly execution yields cooperatively,
+  allowing other async work to run between epochs, but a long-running operation
+  still prevents later operations on the same Store from starting.
   """
 
   alias Wasmex.Engine

--- a/lib/wasmex/store_limits.ex
+++ b/lib/wasmex/store_limits.ex
@@ -19,7 +19,7 @@ defmodule Wasmex.StoreLimits do
       ...>   memory_size: 1_000_000,
       ...>   table_elements: 100_000,
       ...>   instances: 2,
-      ...>   tables: 10
+      ...>   tables: 10,
       ...>   memories: 10
       ...> })
   """

--- a/lib/wasmex/store_or_caller.ex
+++ b/lib/wasmex/store_or_caller.ex
@@ -5,7 +5,7 @@ defmodule Wasmex.StoreOrCaller do
   A Store is a collection of Wasm instances and host-defined state, see `Wasmex.Store`.
   A Caller takes the place of a Store in imported function calls. If a Store is needed in
   Elixir-provided imported functions, always use the provided Caller because
-  using the Store will cause a deadlock (the running Wasm instance locks the Stores Mutex).
+  using the Store will cause a deadlock (the Store is already processing the current Wasm call).
 
   When configured, a StoreOrCaller can consume fuel to halt or yield execution as desired.
   See `Wasmex.EngineConfig.consume_fuel/2` for more information on fuel consumption.
@@ -63,7 +63,12 @@ defmodule Wasmex.StoreOrCaller do
   """
   @spec set_fuel(__MODULE__.t(), pos_integer()) :: :ok | {:error, binary()}
   def set_fuel(%__MODULE__{resource: resource}, fuel) do
-    case Wasmex.Native.store_or_caller_set_fuel(resource, fuel) do
+    result =
+      Wasmex.Utils.native_request(fn from ->
+        Wasmex.Native.store_or_caller_set_fuel(resource, fuel, from)
+      end)
+
+    case result do
       {} -> :ok
       {:error, reason} -> {:error, reason}
     end
@@ -82,7 +87,12 @@ defmodule Wasmex.StoreOrCaller do
   """
   @spec get_fuel(__MODULE__.t()) :: {:ok, pos_integer()} | {:error, binary()}
   def get_fuel(%__MODULE__{resource: resource}) do
-    case Wasmex.Native.store_or_caller_get_fuel(resource) do
+    result =
+      Wasmex.Utils.native_request(fn from ->
+        Wasmex.Native.store_or_caller_get_fuel(resource, from)
+      end)
+
+    case result do
       {:error, reason} -> {:error, reason}
       get_fuel -> {:ok, get_fuel}
     end

--- a/lib/wasmex/utils.ex
+++ b/lib/wasmex/utils.ex
@@ -20,4 +20,14 @@ defmodule Wasmex.Utils do
 
   def stringify(s) when is_binary(s), do: s
   def stringify(s) when is_atom(s), do: Atom.to_string(s)
+
+  @doc false
+  def native_request(request) when is_function(request, 1) do
+    reference = make_ref()
+    :ok = request.({self(), reference})
+
+    receive do
+      {^reference, result} -> result
+    end
+  end
 end

--- a/lib/wasmex/utils.ex
+++ b/lib/wasmex/utils.ex
@@ -22,6 +22,10 @@ defmodule Wasmex.Utils do
   def stringify(s) when is_atom(s), do: Atom.to_string(s)
 
   @doc false
+  def native_timeout(:infinity), do: nil
+  def native_timeout(timeout), do: timeout
+
+  @doc false
   def native_request(request) when is_function(request, 1) do
     reference = make_ref()
     :ok = request.({self(), reference})

--- a/lib/wasmex/wasi/preopen_options.ex
+++ b/lib/wasmex/wasi/preopen_options.ex
@@ -15,7 +15,7 @@ defmodule Wasmex.Wasi.PreopenOptions do
 
         iex> Wasmex.Store.new_wasi(%Wasmex.Wasi.WasiOptions{
         ...>   preopen: [
-        ...>     %PreopenOptions{path: "/tmp", alias: "temp"}
+        ...>     %Wasmex.Wasi.PreopenOptions{path: "/tmp", alias: "temp"}
         ...>   ],
         ...> })
   """

--- a/lib/wasmex/wasi/wasi_options.ex
+++ b/lib/wasmex/wasi/wasi_options.ex
@@ -14,7 +14,7 @@ defmodule Wasmex.Wasi.WasiOptions do
   ## Example
 
       iex> {:ok, stdin} = Wasmex.Pipe.new()
-      iex> Wasmex.Store.new_wasi(%WasiOptions{
+      iex> Wasmex.Store.new_wasi(%Wasmex.Wasi.WasiOptions{
       ...>   args: ["first param", "second param"],
       ...>   env: %{"env_key" => "env_value"},
       ...>   preopen: [

--- a/native/wasmex/README.md
+++ b/native/wasmex/README.md
@@ -6,6 +6,6 @@ To build the NIF module, run:
 cargo build
 ```
 
-It is atomatically build, though, when compiling the elixir sources.
+It is automatically built when compiling the Elixir sources.
 
 The NIF is loaded in `lib/wasmex/native.ex`.

--- a/native/wasmex/src/async_reply.rs
+++ b/native/wasmex/src/async_reply.rs
@@ -1,0 +1,66 @@
+use rustler::{
+    env::SavedTerm, types::tuple::make_tuple, Encoder, Env, LocalPid, NewBinary, OwnedEnv, Term,
+};
+
+/// An owned GenServer-style reply target that can safely cross NIF boundaries.
+pub struct AsyncReply {
+    env: OwnedEnv,
+    from: SavedTerm,
+}
+
+impl AsyncReply {
+    pub fn new(from: Term<'_>) -> Self {
+        let env = OwnedEnv::new();
+        let from = env.save(from);
+        Self { env, from }
+    }
+
+    pub fn send<T: Encoder>(self, value: T) {
+        self.env.run(move |env| {
+            let (pid, reference) = self
+                .from
+                .load(env)
+                .decode::<(LocalPid, Term)>()
+                .expect("async reply target must be a {pid, reference} tuple");
+            let message = make_tuple(env, &[reference, value.encode(env)]);
+            let _ = env.send(&pid, message);
+        });
+    }
+
+    pub fn send_error(self, reason: impl Into<String>) {
+        self.send((crate::atoms::error(), reason.into()));
+    }
+
+    pub fn send_binary(self, bytes: Vec<u8>) {
+        self.env.run(move |env| {
+            let (pid, reference) = self
+                .from
+                .load(env)
+                .decode::<(LocalPid, Term)>()
+                .expect("async reply target must be a {pid, reference} tuple");
+            let mut binary = NewBinary::new(env, bytes.len());
+            binary.as_mut_slice().copy_from_slice(&bytes);
+            let message = make_tuple(env, &[reference, binary.into()]);
+            let _ = env.send(&pid, message);
+        });
+    }
+}
+
+pub fn submit_error(reply: AsyncReply, error: crate::store_executor::SubmitError) {
+    let reason = match error {
+        crate::store_executor::SubmitError::Busy => "Wasm store command queue is full",
+        crate::store_executor::SubmitError::Closed => "Wasm store is closed",
+    };
+    reply.send_error(reason);
+}
+
+pub fn send_saved_term(env: OwnedEnv, from: SavedTerm, value: SavedTerm) {
+    env.run(|env: Env| {
+        let (pid, reference) = from
+            .load(env)
+            .decode::<(LocalPid, Term)>()
+            .expect("async reply target must be a {pid, reference} tuple");
+        let message = make_tuple(env, &[reference, value.load(env)]);
+        let _ = env.send(&pid, message);
+    });
+}

--- a/native/wasmex/src/async_reply.rs
+++ b/native/wasmex/src/async_reply.rs
@@ -1,29 +1,30 @@
 use rustler::{
-    env::SavedTerm, types::tuple::make_tuple, Encoder, Env, LocalPid, NewBinary, OwnedEnv, Term,
+    env::SavedTerm, types::tuple::make_tuple, Encoder, LocalPid, NewBinary, OwnedEnv, Term,
 };
 
 /// An owned GenServer-style reply target that can safely cross NIF boundaries.
 pub struct AsyncReply {
     env: OwnedEnv,
-    from: SavedTerm,
+    pid: LocalPid,
+    reference: SavedTerm,
 }
 
 impl AsyncReply {
-    pub fn new(from: Term<'_>) -> Self {
+    pub fn new(from: Term<'_>) -> rustler::NifResult<Self> {
+        let (pid, reference) = from.decode::<(LocalPid, Term)>()?;
         let env = OwnedEnv::new();
-        let from = env.save(from);
-        Self { env, from }
+        let reference = env.save(reference);
+        Ok(Self {
+            env,
+            pid,
+            reference,
+        })
     }
 
     pub fn send<T: Encoder>(self, value: T) {
         self.env.run(move |env| {
-            let (pid, reference) = self
-                .from
-                .load(env)
-                .decode::<(LocalPid, Term)>()
-                .expect("async reply target must be a {pid, reference} tuple");
-            let message = make_tuple(env, &[reference, value.encode(env)]);
-            let _ = env.send(&pid, message);
+            let message = make_tuple(env, &[self.reference.load(env), value.encode(env)]);
+            let _ = env.send(&self.pid, message);
         });
     }
 
@@ -33,15 +34,18 @@ impl AsyncReply {
 
     pub fn send_binary(self, bytes: Vec<u8>) {
         self.env.run(move |env| {
-            let (pid, reference) = self
-                .from
-                .load(env)
-                .decode::<(LocalPid, Term)>()
-                .expect("async reply target must be a {pid, reference} tuple");
             let mut binary = NewBinary::new(env, bytes.len());
             binary.as_mut_slice().copy_from_slice(&bytes);
-            let message = make_tuple(env, &[reference, binary.into()]);
-            let _ = env.send(&pid, message);
+            let message = make_tuple(env, &[self.reference.load(env), binary.into()]);
+            let _ = env.send(&self.pid, message);
+        });
+    }
+
+    pub fn send_saved(self, source_env: OwnedEnv, value: SavedTerm) {
+        let value = source_env.run(|env| self.env.save(value.load(env)));
+        self.env.run(move |env| {
+            let message = make_tuple(env, &[self.reference.load(env), value.load(env)]);
+            let _ = env.send(&self.pid, message);
         });
     }
 }
@@ -52,15 +56,4 @@ pub fn submit_error(reply: AsyncReply, error: crate::store_executor::SubmitError
         crate::store_executor::SubmitError::Closed => "Wasm store is closed",
     };
     reply.send_error(reason);
-}
-
-pub fn send_saved_term(env: OwnedEnv, from: SavedTerm, value: SavedTerm) {
-    env.run(|env: Env| {
-        let (pid, reference) = from
-            .load(env)
-            .decode::<(LocalPid, Term)>()
-            .expect("async reply target must be a {pid, reference} tuple");
-        let message = make_tuple(env, &[reference, value.load(env)]);
-        let _ = env.send(&pid, message);
-    });
 }

--- a/native/wasmex/src/caller.rs
+++ b/native/wasmex/src/caller.rs
@@ -2,7 +2,7 @@ use tokio::sync::mpsc;
 use wasmtime::{Caller, Engine, Instance, Memory, Trap, Val, ValType};
 
 use crate::{
-    async_reply::{send_saved_term, AsyncReply},
+    async_reply::AsyncReply,
     functions,
     instance::{decode_function_param_terms, map_wasm_values_to_vals},
     instance::{decode_term_as_wasm_value, send_global_value},
@@ -11,7 +11,8 @@ use crate::{
     store::StoreData,
 };
 use rustler::{env::SavedTerm, types::tuple::make_tuple, Encoder, OwnedEnv, ResourceArc, Term};
-use std::sync::Mutex;
+
+const CALLBACK_QUEUE_CAPACITY: usize = 1024;
 
 pub enum CallerCommand {
     GetFuel {
@@ -57,7 +58,7 @@ pub enum CallerCommand {
         function_name: String,
         env: OwnedEnv,
         params: SavedTerm,
-        from: SavedTerm,
+        reply: AsyncReply,
     },
     NewInstance {
         module: wasmtime::Module,
@@ -88,13 +89,13 @@ pub enum CallerCommand {
 
 #[derive(Clone)]
 pub struct CallbackSession {
-    sender: mpsc::UnboundedSender<CallerCommand>,
+    sender: mpsc::Sender<CallerCommand>,
     engine: Engine,
 }
 
 impl CallbackSession {
-    pub fn new(engine: Engine) -> (Self, mpsc::UnboundedReceiver<CallerCommand>) {
-        let (sender, receiver) = mpsc::unbounded_channel();
+    pub fn new(engine: Engine) -> (Self, mpsc::Receiver<CallerCommand>) {
+        let (sender, receiver) = mpsc::channel(CALLBACK_QUEUE_CAPACITY);
         (Self { sender, engine }, receiver)
     }
 
@@ -102,8 +103,47 @@ impl CallbackSession {
         &self.engine
     }
 
-    pub fn submit(&self, command: CallerCommand) -> Result<(), CallerCommand> {
-        self.sender.send(command).map_err(|error| error.0)
+    pub fn submit(&self, command: CallerCommand) -> Result<(), CallbackSubmitError> {
+        self.sender.try_send(command).map_err(|error| match error {
+            mpsc::error::TrySendError::Full(command) => CallbackSubmitError::Busy(command),
+            mpsc::error::TrySendError::Closed(command) => CallbackSubmitError::Closed(command),
+        })
+    }
+}
+
+pub enum CallbackSubmitError {
+    Busy(CallerCommand),
+    Closed(CallerCommand),
+}
+
+impl CallbackSubmitError {
+    pub fn reject(self) {
+        let (command, reason) = match self {
+            Self::Busy(command) => (command, "Wasm callback Caller command queue is full"),
+            Self::Closed(command) => (command, "Caller is no longer valid"),
+        };
+        command.reject(reason);
+    }
+}
+
+impl CallerCommand {
+    fn reject(self, reason: &'static str) {
+        let reply = match self {
+            Self::GetFuel { reply }
+            | Self::SetFuel { reply, .. }
+            | Self::MemoryFromInstance { reply, .. }
+            | Self::MemorySize { reply, .. }
+            | Self::MemoryGetByte { reply, .. }
+            | Self::MemorySetByte { reply, .. }
+            | Self::MemoryRead { reply, .. }
+            | Self::MemoryWrite { reply, .. }
+            | Self::CallExported { reply, .. }
+            | Self::NewInstance { reply, .. }
+            | Self::GetGlobal { reply, .. }
+            | Self::SetGlobal { reply, .. }
+            | Self::FunctionExists { reply, .. } => reply,
+        };
+        reply.send_error(reason);
     }
 }
 
@@ -119,9 +159,7 @@ pub async fn handle_command(caller: &mut Caller<'_, StoreData>, command: CallerC
         },
         CallerCommand::MemoryFromInstance { instance, reply } => {
             match memory_from_instance(&instance, &mut *caller) {
-                Ok(memory) => reply.send(ResourceArc::new(MemoryResource {
-                    inner: Mutex::new(memory),
-                })),
+                Ok(memory) => reply.send(ResourceArc::new(MemoryResource { inner: memory })),
                 Err(error) => reply.send_error(error),
             }
         }
@@ -174,7 +212,7 @@ pub async fn handle_command(caller: &mut Caller<'_, StoreData>, command: CallerC
             function_name,
             env,
             params,
-            from,
+            reply,
         } => {
             let prepared = env.run(|term_env| {
                 let given_params = params
@@ -234,7 +272,7 @@ pub async fn handle_command(caller: &mut Caller<'_, StoreData>, command: CallerC
                 Err(reason) => env.run(|term_env| term_env.error_tuple(reason).encode(term_env)),
             };
             let result = env.save(result);
-            send_saved_term(env, from, result);
+            reply.send_saved(env, result);
         }
         CallerCommand::NewInstance {
             module,

--- a/native/wasmex/src/caller.rs
+++ b/native/wasmex/src/caller.rs
@@ -1,53 +1,323 @@
-use std::{
-    collections::HashMap,
-    sync::{LazyLock, Mutex},
+use tokio::sync::mpsc;
+use wasmtime::{Caller, Engine, Instance, Memory, Trap, Val, ValType};
+
+use crate::{
+    async_reply::{send_saved_term, AsyncReply},
+    functions,
+    instance::{decode_function_param_terms, map_wasm_values_to_vals},
+    instance::{decode_term_as_wasm_value, send_global_value},
+    memory::{memory_from_instance, MemoryResource},
+    printable_term_type::PrintableTermType,
+    store::StoreData,
 };
-use wasmtime::Caller;
+use rustler::{env::SavedTerm, types::tuple::make_tuple, Encoder, OwnedEnv, ResourceArc, Term};
+use std::sync::Mutex;
 
-use crate::store::StoreData;
-
-// Thread-safe map to store Wasmtime Caller instances under their token id
-// A token can be obtained by passing a `Caller` to `set_caller` in exchange for a fresh token.
-// That token can then be used to retrieve references to the `Caller` instance later.
-// This is needed to pass down the `Caller` to host functions that are invoked from Wasm but Rust
-// didn't let us do that directly.
-static CALLER_MAP: LazyLock<Mutex<HashMap<i32, Caller<StoreData>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-pub(crate) fn get_caller(token: &i32) -> Option<&Caller<'_, StoreData>> {
-    let map = &*(CALLER_MAP.lock().unwrap());
-    map.get(token).map(|caller| unsafe {
-        std::mem::transmute::<&Caller<'_, StoreData>, &Caller<'_, StoreData>>(caller)
-    })
+pub enum CallerCommand {
+    GetFuel {
+        reply: AsyncReply,
+    },
+    SetFuel {
+        fuel: u64,
+        reply: AsyncReply,
+    },
+    MemoryFromInstance {
+        instance: Instance,
+        reply: AsyncReply,
+    },
+    MemorySize {
+        memory: Memory,
+        reply: AsyncReply,
+    },
+    MemoryGetByte {
+        memory: Memory,
+        index: usize,
+        reply: AsyncReply,
+    },
+    MemorySetByte {
+        memory: Memory,
+        index: usize,
+        value: u8,
+        reply: AsyncReply,
+    },
+    MemoryRead {
+        memory: Memory,
+        index: usize,
+        len: usize,
+        reply: AsyncReply,
+    },
+    MemoryWrite {
+        memory: Memory,
+        index: usize,
+        bytes: Vec<u8>,
+        reply: AsyncReply,
+    },
+    CallExported {
+        instance: Instance,
+        function_name: String,
+        env: OwnedEnv,
+        params: SavedTerm,
+        from: SavedTerm,
+    },
+    NewInstance {
+        module: wasmtime::Module,
+        linked_modules: Vec<crate::instance::OwnedLinkedModule>,
+        callback_pid: rustler::LocalPid,
+        env: OwnedEnv,
+        imports: SavedTerm,
+        reply: AsyncReply,
+    },
+    GetGlobal {
+        instance: Instance,
+        name: String,
+        reply: AsyncReply,
+    },
+    SetGlobal {
+        instance: Instance,
+        name: String,
+        env: OwnedEnv,
+        value: SavedTerm,
+        reply: AsyncReply,
+    },
+    FunctionExists {
+        instance: Instance,
+        name: String,
+        reply: AsyncReply,
+    },
 }
 
-pub(crate) fn get_caller_mut(token: &mut i32) -> Option<&mut Caller<'_, StoreData>> {
-    let map = &mut *(CALLER_MAP.lock().unwrap());
-    map.get_mut(token).map(|caller| unsafe {
-        std::mem::transmute::<&mut Caller<'_, StoreData>, &mut Caller<'_, StoreData>>(caller)
-    })
+#[derive(Clone)]
+pub struct CallbackSession {
+    sender: mpsc::UnboundedSender<CallerCommand>,
+    engine: Engine,
 }
 
-pub(crate) fn set_caller(caller: Caller<StoreData>) -> i32 {
-    let mut map = CALLER_MAP.lock().unwrap();
-    let token = generate_unique_random_token(&map);
+impl CallbackSession {
+    pub fn new(engine: Engine) -> (Self, mpsc::UnboundedReceiver<CallerCommand>) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        (Self { sender, engine }, receiver)
+    }
 
-    let caller =
-        unsafe { std::mem::transmute::<Caller<'_, StoreData>, Caller<'static, StoreData>>(caller) };
-    map.insert(token, caller);
-    token
-}
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
 
-fn generate_unique_random_token(map: &HashMap<i32, Caller<'_, StoreData>>) -> i32 {
-    loop {
-        let token: i32 = rand::random();
-        if !map.contains_key(&token) {
-            break token;
-        }
+    pub fn submit(&self, command: CallerCommand) -> Result<(), CallerCommand> {
+        self.sender.send(command).map_err(|error| error.0)
     }
 }
 
-pub(crate) fn remove_caller(token: i32) {
-    let mut map = CALLER_MAP.lock().unwrap();
-    map.remove(&token);
+pub async fn handle_command(caller: &mut Caller<'_, StoreData>, command: CallerCommand) {
+    match command {
+        CallerCommand::GetFuel { reply } => match caller.get_fuel() {
+            Ok(fuel) => reply.send(fuel),
+            Err(error) => reply.send_error(format!("Could not get fuel: {error}")),
+        },
+        CallerCommand::SetFuel { fuel, reply } => match caller.set_fuel(fuel) {
+            Ok(()) => reply.send(()),
+            Err(error) => reply.send_error(format!("Could not set fuel: {error}")),
+        },
+        CallerCommand::MemoryFromInstance { instance, reply } => {
+            match memory_from_instance(&instance, &mut *caller) {
+                Ok(memory) => reply.send(ResourceArc::new(MemoryResource {
+                    inner: Mutex::new(memory),
+                })),
+                Err(error) => reply.send_error(error),
+            }
+        }
+        CallerCommand::MemorySize { memory, reply } => {
+            reply.send(memory.data_size(&*caller));
+        }
+        CallerCommand::MemoryGetByte {
+            memory,
+            index,
+            reply,
+        } => {
+            let mut buffer = [0];
+            match memory.read(&*caller, index, &mut buffer) {
+                Ok(()) => reply.send(buffer[0]),
+                Err(error) => reply.send_error(error.to_string()),
+            }
+        }
+        CallerCommand::MemorySetByte {
+            memory,
+            index,
+            value,
+            reply,
+        } => match memory.write(&mut *caller, index, &[value]) {
+            Ok(()) => reply.send(crate::atoms::ok()),
+            Err(error) => reply.send_error(error.to_string()),
+        },
+        CallerCommand::MemoryRead {
+            memory,
+            index,
+            len,
+            reply,
+        } => {
+            let mut buffer = vec![0; len];
+            match memory.read(&*caller, index, &mut buffer) {
+                Ok(()) => reply.send_binary(buffer),
+                Err(error) => reply.send_error(error.to_string()),
+            }
+        }
+        CallerCommand::MemoryWrite {
+            memory,
+            index,
+            bytes,
+            reply,
+        } => match memory.write(&mut *caller, index, &bytes) {
+            Ok(()) => reply.send(crate::atoms::ok()),
+            Err(error) => reply.send_error(error.to_string()),
+        },
+        CallerCommand::CallExported {
+            instance,
+            function_name,
+            env,
+            params,
+            from,
+        } => {
+            let prepared = env.run(|term_env| {
+                let given_params = params
+                    .load(term_env)
+                    .decode::<Vec<Term>>()
+                    .map_err(|_| "could not load 'function params'".to_string())?;
+                let function = functions::find(&instance, &mut *caller, &function_name)
+                    .ok_or_else(|| format!("exported function `{function_name}` not found"))?;
+                let params = decode_function_param_terms(
+                    &function.ty(&*caller).params().collect::<Vec<ValType>>(),
+                    given_params,
+                )
+                .map(|values| map_wasm_values_to_vals(&values))?;
+                let result_count = function.ty(&*caller).results().len();
+                Ok::<_, String>((function, params, result_count))
+            });
+
+            let result = match prepared {
+                Ok((function, params, result_count)) => {
+                    let mut results = vec![Val::null_extern_ref(); result_count];
+                    match function
+                        .call_async(&mut *caller, params.as_slice(), &mut results)
+                        .await
+                    {
+                        Ok(()) => env.run(|term_env| {
+                            let values = results
+                                .into_iter()
+                                .map(|value| encode_core_value(term_env, value))
+                                .collect::<Result<Vec<_>, _>>();
+                            match values {
+                                Ok(values) => make_tuple(
+                                    term_env,
+                                    &[crate::atoms::ok().encode(term_env), values.encode(term_env)],
+                                )
+                                .encode(term_env),
+                                Err(reason) => term_env.error_tuple(reason).encode(term_env),
+                            }
+                        }),
+                        Err(error) => env.run(|term_env| {
+                            let reason = format!("{error}");
+                            if let Ok(trap) = error.downcast::<Trap>() {
+                                term_env
+                                    .error_tuple(format!(
+                                        "Error during function excecution ({trap}): {reason}"
+                                    ))
+                                    .encode(term_env)
+                            } else {
+                                term_env
+                                    .error_tuple(format!(
+                                        "Error during function excecution: {reason}"
+                                    ))
+                                    .encode(term_env)
+                            }
+                        }),
+                    }
+                }
+                Err(reason) => env.run(|term_env| term_env.error_tuple(reason).encode(term_env)),
+            };
+            let result = env.save(result);
+            send_saved_term(env, from, result);
+        }
+        CallerCommand::NewInstance {
+            module,
+            linked_modules,
+            callback_pid,
+            env,
+            imports,
+            reply,
+        } => match crate::instance::instantiate(
+            &mut *caller,
+            module,
+            linked_modules,
+            callback_pid,
+            env,
+            imports,
+        )
+        .await
+        {
+            Ok(instance) => reply.send(instance),
+            Err(error) => reply.send_error(error),
+        },
+        CallerCommand::GetGlobal {
+            instance,
+            name,
+            reply,
+        } => match instance
+            .get_global(&mut *caller, &name)
+            .ok_or_else(|| format!("exported global `{name}` not found"))
+            .map(|global| global.get(&mut *caller))
+        {
+            Ok(value) => send_global_value(reply, value),
+            Err(error) => reply.send_error(error),
+        },
+        CallerCommand::SetGlobal {
+            instance,
+            name,
+            env,
+            value,
+            reply,
+        } => {
+            let result = env.run(|term_env| {
+                let term = value.load(term_env);
+                let global = instance
+                    .get_global(&mut *caller, &name)
+                    .ok_or_else(|| format!("exported global `{name}` not found"))?;
+                let global_type = global.ty(&*caller).content().clone();
+                let value =
+                    decode_term_as_wasm_value(global_type.clone(), term).ok_or_else(|| {
+                        format!(
+                            "Cannot convert to a WebAssembly {:?} value. Given `{:?}`.",
+                            global_type,
+                            PrintableTermType::PrintTerm(term.get_type())
+                        )
+                    })?;
+                let value = map_wasm_values_to_vals(&[value]).remove(0);
+                global
+                    .set(&mut *caller, value)
+                    .map_err(|error| format!("Could not set global: {error}"))
+            });
+            match result {
+                Ok(()) => reply.send(()),
+                Err(error) => reply.send_error(error),
+            }
+        }
+        CallerCommand::FunctionExists {
+            instance,
+            name,
+            reply,
+        } => reply.send(functions::exists(&instance, &mut *caller, &name)),
+    }
+}
+
+fn encode_core_value<'a>(env: rustler::Env<'a>, value: Val) -> Result<Term<'a>, &'static str> {
+    match value {
+        Val::I32(value) => Ok(value.encode(env)),
+        Val::I64(value) => Ok(value.encode(env)),
+        Val::F32(value) => Ok(f32::from_bits(value).encode(env)),
+        Val::F64(value) => Ok(f64::from_bits(value).encode(env)),
+        Val::V128(value) => Ok(rustler::BigInt::from(value.as_u128()).encode(env)),
+        Val::FuncRef(_) => Err("unable_to_return_func_ref_type"),
+        Val::ExternRef(_) => Err("unable_to_return_extern_ref_type"),
+        Val::AnyRef(_) => Err("unable_to_return_any_ref_type"),
+        Val::ExnRef(_) => Err("unable_to_return_exn_ref_type"),
+        Val::ContRef(_) => Err("unable_to_return_cont_ref_type"),
+    }
 }

--- a/native/wasmex/src/component.rs
+++ b/native/wasmex/src/component.rs
@@ -1,9 +1,8 @@
-use crate::store::{ComponentStoreData, ComponentStoreResource};
+use crate::store::ComponentStoreResource;
 use rustler::Binary;
 use rustler::Error;
 use rustler::NifResult;
 use rustler::ResourceArc;
-use wasmtime::Store;
 use wit_parser::decoding::DecodedWasm;
 use wit_parser::Resolve;
 use wit_parser::WorldId;
@@ -29,12 +28,7 @@ pub fn new_component(
     store_or_caller_resource: ResourceArc<ComponentStoreResource>,
     component_binary: Binary,
 ) -> NifResult<ResourceArc<ComponentResource>> {
-    let store_or_caller: &mut Store<ComponentStoreData> =
-        &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource as the mutex was poisoned: {e}"
-            )))
-        })?);
+    let executor = store_or_caller_resource.executor()?;
     let bytes = component_binary.as_slice();
     let decoded_wasm = wit_parser::decoding::decode(bytes)
         .map_err(|e| Error::Term(Box::new(format!("Unable to decode WASM: {e}"))))?;
@@ -45,7 +39,7 @@ pub fn new_component(
         DecodedWasm::Component(resolve, world_id) => ParsedComponent { world_id, resolve },
     };
 
-    let component = Component::new(store_or_caller.engine(), bytes)
+    let component = Component::new(executor.engine(), bytes)
         .map_err(|err| rustler::Error::Term(Box::new(err.to_string())))?;
 
     Ok(ResourceArc::new(ComponentResource {

--- a/native/wasmex/src/component_instance.rs
+++ b/native/wasmex/src/component_instance.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 use rustler::env::SavedTerm;
 use wit_parser::{Function, Resolve, WorldItem};
 
-use crate::async_reply::{send_saved_term, submit_error, AsyncReply};
+use crate::async_reply::{submit_error, AsyncReply};
 use crate::atoms;
 use crate::component::ComponentResource;
 use crate::store::ComponentStoreData;
@@ -41,7 +41,7 @@ pub struct ComponentCallbackTokenResource {
 impl rustler::Resource for ComponentCallbackTokenResource {}
 
 pub struct ComponentInstanceResource {
-    pub inner: Mutex<Instance>,
+    pub inner: Instance,
 }
 
 #[rustler::resource_impl()]
@@ -67,8 +67,8 @@ pub fn new_instance(
     let term_env = OwnedEnv::new();
     let imports = term_env.save(imports);
     let executor = store_resource.executor()?;
-    let reply = AsyncReply::new(from);
-    let submit_reply = AsyncReply::new(from);
+    let reply = AsyncReply::new(from)?;
+    let submit_reply = AsyncReply::new(from)?;
 
     if let Err(error) = executor.submit(move |mut store| async move {
         let linker = term_env
@@ -82,11 +82,7 @@ pub fn new_instance(
             Ok(linker) => linker
                 .instantiate_async(&mut store, &component)
                 .await
-                .map(|instance| {
-                    ResourceArc::new(ComponentInstanceResource {
-                        inner: Mutex::new(instance),
-                    })
-                })
+                .map(|instance| ResourceArc::new(ComponentInstanceResource { inner: instance }))
                 .map_err(|error| error.to_string()),
             Err(error) => Err(error),
         };
@@ -220,50 +216,37 @@ pub fn call_exported_function(
     given_params: Term,
     from: Term,
     timeout_ms: Option<u64>,
-) -> rustler::Atom {
-    let executor = match component_store_resource.executor() {
-        Ok(executor) => executor,
-        Err(error) => {
-            AsyncReply::new(from).send_error(format!("{error:?}"));
-            return atoms::ok();
-        }
-    };
-    let instance = match instance_resource.inner.lock() {
-        Ok(instance) => *instance,
-        Err(error) => {
-            AsyncReply::new(from)
-                .send_error(format!("Could not unlock component instance: {error}"));
-            return atoms::ok();
-        }
-    };
+) -> NifResult<rustler::Atom> {
+    let reply = AsyncReply::new(from)?;
+    let executor = component_store_resource.executor()?;
+    let instance = instance_resource.inner;
     let mut thread_env = OwnedEnv::new();
     let function_params = thread_env.save(given_params);
-    let saved_from = thread_env.save(from);
-    let submit_reply = AsyncReply::new(from);
+    let submit_reply = AsyncReply::new(from)?;
     let deadline = timeout_ms
         .map(|timeout| tokio::time::Instant::now() + std::time::Duration::from_millis(timeout));
 
     if let Err(error) = executor.submit(move |mut store| async move {
+        if deadline.is_some_and(|deadline| tokio::time::Instant::now() >= deadline) {
+            return store;
+        }
         let result = component_execute_function(
             &mut thread_env,
             &mut store,
             instance,
             function_name_path,
             function_params,
-        );
-        let result = match deadline {
-            Some(deadline) => tokio::time::timeout_at(deadline, result).await.ok(),
-            None => Some(result.await),
-        };
-        if let Some(result) = result {
-            send_saved_term(thread_env, saved_from, result);
+        )
+        .await;
+        if deadline.is_none_or(|deadline| tokio::time::Instant::now() < deadline) {
+            reply.send_saved(thread_env, result);
         }
         store
     }) {
         submit_error(submit_reply, error);
     }
 
-    atoms::ok()
+    Ok(atoms::ok())
 }
 
 async fn component_execute_function(
@@ -448,11 +431,9 @@ pub fn receive_callback_result(
     let return_values =
         match convert_return_values(&component_resource.parsed.resolve, import_function, result) {
             Ok(values) => values,
-            Err(error) => {
+            Err(_) => {
                 send_component_callback_result(&token_resource, false, vec![])?;
-                return Err(Error::Term(Box::new(format!(
-                    "Failed to convert imported function return values - {error}"
-                ))));
+                return Ok(atoms::ok());
             }
         };
     send_component_callback_result(&token_resource, true, return_values)?;
@@ -500,7 +481,6 @@ fn send_component_callback_result(
         })?
         .take()
         .ok_or_else(|| Error::Term(Box::new("Component callback result was already sent")))?;
-    sender
-        .send((success, values))
-        .map_err(|_| Error::Term(Box::new("Component callback is no longer waiting")))
+    let _ = sender.send((success, values));
+    Ok(())
 }

--- a/native/wasmex/src/component_instance.rs
+++ b/native/wasmex/src/component_instance.rs
@@ -1,15 +1,14 @@
 use std::collections::HashMap;
-use std::sync::{Condvar, Mutex};
+use std::sync::Mutex;
 
 use rustler::env::SavedTerm;
 use wit_parser::{Function, Resolve, WorldItem};
 
+use crate::async_reply::{send_saved_term, submit_error, AsyncReply};
 use crate::atoms;
 use crate::component::ComponentResource;
-use crate::engine::TOKIO_RUNTIME;
 use crate::store::ComponentStoreData;
 use crate::store::ComponentStoreResource;
-use rustler::types::tuple::make_tuple;
 use rustler::NifResult;
 use rustler::ResourceArc;
 use rustler::{Encoder, OwnedEnv};
@@ -19,8 +18,6 @@ use wasmtime::{Error as WasmtimeError, Trap};
 
 use rustler::Term;
 
-use wasmtime::Store;
-
 use wasmtime_wasi;
 use wasmtime_wasi_http;
 
@@ -28,11 +25,12 @@ use crate::component_type_conversion::{
     convert_params, convert_result_term, encode_result, vals_to_terms,
 };
 
+type ComponentCallbackSender = tokio::sync::oneshot::Sender<(bool, Vec<Val>)>;
+
 pub struct ComponentCallbackToken {
-    pub continue_signal: Condvar,
     pub name: String,
     pub namespace: Option<String>,
-    pub return_values: Mutex<Option<(bool, Vec<Val>)>>,
+    pub return_sender: Mutex<Option<ComponentCallbackSender>>,
 }
 
 pub struct ComponentCallbackTokenResource {
@@ -53,78 +51,109 @@ impl rustler::Resource for ComponentInstanceResource {}
 pub fn new_instance(
     store_resource: ResourceArc<ComponentStoreResource>,
     component_resource: ResourceArc<ComponentResource>,
-    imports: rustler::Term,
-) -> NifResult<ResourceArc<ComponentInstanceResource>> {
-    let store: &mut Store<ComponentStoreData> =
-        &mut *(store_resource.inner.lock().map_err(|e| {
+    imports: Term,
+    from: Term,
+) -> NifResult<rustler::Atom> {
+    let component = component_resource
+        .inner
+        .lock()
+        .map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock store resource as the mutex was poisoned: {e}"
+                "Could not unlock component resource as the mutex was poisoned: {e}"
             )))
-        })?);
+        })?
+        .clone();
+    let callback_pid = imports.get_env().pid();
+    let term_env = OwnedEnv::new();
+    let imports = term_env.save(imports);
+    let executor = store_resource.executor()?;
+    let reply = AsyncReply::new(from);
+    let submit_reply = AsyncReply::new(from);
 
-    let component = component_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!(
-            "Could not unlock component resource as the mutex was poisoned: {e}"
-        )))
-    })?;
+    if let Err(error) = executor.submit(move |mut store| async move {
+        let linker = term_env
+            .run(|env| {
+                let imports = imports.load(env);
+                create_linker(&store, imports, callback_pid)
+            })
+            .map_err(|error| format!("{error:?}"));
 
-    let mut linker = Linker::new(store.engine());
-    linker.allow_shadowing(true);
-    wasmtime_wasi::p2::add_to_linker_sync(&mut linker)
-        .map_err(|e| rustler::Error::Term(Box::new(e.to_string())))?;
-    if store.data().http.is_some() {
-        wasmtime_wasi_http::p2::add_only_http_to_linker_sync(&mut linker)
-            .map_err(|e| rustler::Error::Term(Box::new(e.to_string())))?;
+        let result = match linker {
+            Ok(linker) => linker
+                .instantiate_async(&mut store, &component)
+                .await
+                .map(|instance| {
+                    ResourceArc::new(ComponentInstanceResource {
+                        inner: Mutex::new(instance),
+                    })
+                })
+                .map_err(|error| error.to_string()),
+            Err(error) => Err(error),
+        };
+
+        match result {
+            Ok(instance) => reply.send(instance),
+            Err(error) => reply.send_error(error),
+        }
+        store
+    }) {
+        submit_error(submit_reply, error);
     }
 
-    // Instantiate the component
+    Ok(atoms::ok())
+}
 
-    // Handle imports
+fn create_linker(
+    store: &wasmtime::Store<ComponentStoreData>,
+    imports: Term,
+    callback_pid: LocalPid,
+) -> NifResult<Linker<ComponentStoreData>> {
+    let mut linker = Linker::new(store.engine());
+    linker.allow_shadowing(true);
+    wasmtime_wasi::p2::add_to_linker_async(&mut linker)
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    if store.data().http.is_some() {
+        wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker)
+            .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    }
+
     let imports_map = imports.decode::<HashMap<String, Term>>()?;
     for (name, implementation) in imports_map {
         if Term::is_tuple(implementation) {
-            // root imports
-            link_import(&mut linker.root(), name, None, implementation)?;
+            link_import(&mut linker.root(), name, None, callback_pid)?;
         } else {
             let imports_map = implementation.decode::<HashMap<String, Term>>()?;
             let mut namespace = linker
                 .instance(&name)
-                .map_err(|e| rustler::Error::Term(Box::new(e.to_string())))?;
-            for (implementation_name, implementation) in imports_map {
+                .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+            for implementation_name in imports_map.into_keys() {
                 link_import(
                     &mut namespace,
                     implementation_name,
                     Some(name.clone()),
-                    implementation,
+                    callback_pid,
                 )?;
             }
         }
     }
-
-    let instance = linker
-        .instantiate(&mut *store, &component)
-        .map_err(|e| rustler::Error::Term(Box::new(e.to_string())))?;
-
-    Ok(ResourceArc::new(ComponentInstanceResource {
-        inner: Mutex::new(instance),
-    }))
+    Ok(linker)
 }
 
 fn create_callback_token(
     name: String,
     namespace: Option<String>,
+    return_sender: tokio::sync::oneshot::Sender<(bool, Vec<Val>)>,
 ) -> ResourceArc<ComponentCallbackTokenResource> {
     ResourceArc::new(ComponentCallbackTokenResource {
         token: ComponentCallbackToken {
-            continue_signal: Condvar::new(),
             name,
             namespace,
-            return_values: Mutex::new(None),
+            return_sender: Mutex::new(Some(return_sender)),
         },
     })
 }
 
-fn call_elixir_import(
+async fn call_elixir_import(
     name: String,
     namespace: Option<String>,
     params: &[Val],
@@ -132,7 +161,8 @@ fn call_elixir_import(
     pid: LocalPid,
 ) -> Result<(), WasmtimeError> {
     let mut msg_env = OwnedEnv::new();
-    let callback_token = create_callback_token(name.clone(), namespace.clone());
+    let (return_sender, return_receiver) = tokio::sync::oneshot::channel();
+    let callback_token = create_callback_token(name.clone(), namespace.clone(), return_sender);
 
     let _ = msg_env.send_and_clear(&pid, |env| {
         let param_terms = vals_to_terms(params, env);
@@ -145,12 +175,9 @@ fn call_elixir_import(
         )
     });
 
-    let mut result = callback_token.token.return_values.lock().unwrap();
-    while result.is_none() {
-        result = callback_token.token.continue_signal.wait(result).unwrap();
-    }
-
-    let (success, returned_values) = result.take().unwrap();
+    let (success, returned_values) = return_receiver
+        .await
+        .map_err(|_| WasmtimeError::msg("Component callback result channel closed"))?;
     if !success {
         return Err(WasmtimeError::msg("Callback failed"));
     }
@@ -165,22 +192,21 @@ fn link_import(
     linker_instance: &mut LinkerInstance<ComponentStoreData>,
     name: String,
     namespace: Option<String>,
-    implementation: Term,
+    pid: LocalPid,
 ) -> NifResult<()> {
-    let pid = implementation.get_env().pid();
     let name_for_closure = name.clone();
 
     linker_instance
-        .func_new(
+        .func_new_async(
             &name,
             move |_store, _function_type, params, result_values| {
-                call_elixir_import(
+                Box::new(call_elixir_import(
                     name_for_closure.clone(),
                     namespace.clone(),
                     params,
                     result_values,
                     pid,
-                )
+                ))
             },
         )
         .map_err(|e| rustler::Error::Term(Box::new(e.to_string())))
@@ -193,67 +219,66 @@ pub fn call_exported_function(
     function_name_path: Vec<String>,
     given_params: Term,
     from: Term,
+    timeout_ms: Option<u64>,
 ) -> rustler::Atom {
-    // create erlang environment for the thread
+    let executor = match component_store_resource.executor() {
+        Ok(executor) => executor,
+        Err(error) => {
+            AsyncReply::new(from).send_error(format!("{error:?}"));
+            return atoms::ok();
+        }
+    };
+    let instance = match instance_resource.inner.lock() {
+        Ok(instance) => *instance,
+        Err(error) => {
+            AsyncReply::new(from)
+                .send_error(format!("Could not unlock component instance: {error}"));
+            return atoms::ok();
+        }
+    };
     let mut thread_env = OwnedEnv::new();
-    // copy over params into the thread environment
     let function_params = thread_env.save(given_params);
-    let from = thread_env.save(from);
+    let saved_from = thread_env.save(from);
+    let submit_reply = AsyncReply::new(from);
+    let deadline = timeout_ms
+        .map(|timeout| tokio::time::Instant::now() + std::time::Duration::from_millis(timeout));
 
-    TOKIO_RUNTIME.spawn_blocking(move || {
-        // Execute function and get the result
+    if let Err(error) = executor.submit(move |mut store| async move {
         let result = component_execute_function(
             &mut thread_env,
-            component_store_resource,
-            instance_resource,
+            &mut store,
+            instance,
             function_name_path,
             function_params,
         );
-
-        // Send result directly to the caller
-        thread_env.run(|env| {
-            let from_tuple = from.load(env).decode::<Term>().unwrap();
-            let result_term = result
-                .load(env)
-                .decode::<Term>()
-                .unwrap_or(atoms::error().encode(env));
-
-            // GenServer.call from tuple is {pid, ref}
-            // LocalPid in Rustler can handle both local and remote PIDs (despite the name)
-            let (caller_pid, ref_term) = from_tuple
-                .decode::<(LocalPid, Term)>()
-                .expect("from must be a GenServer {pid, ref} tuple");
-
-            // Send GenServer reply format directly to caller: {ref, result}
-            let _ = env.send(&caller_pid, make_tuple(env, &[ref_term, result_term]));
-        });
-    });
+        let result = match deadline {
+            Some(deadline) => tokio::time::timeout_at(deadline, result).await.ok(),
+            None => Some(result.await),
+        };
+        if let Some(result) = result {
+            send_saved_term(thread_env, saved_from, result);
+        }
+        store
+    }) {
+        submit_error(submit_reply, error);
+    }
 
     atoms::ok()
 }
 
-fn component_execute_function(
+async fn component_execute_function(
     thread_env: &mut OwnedEnv,
-    component_store_resource: ResourceArc<ComponentStoreResource>,
-    instance_resource: ResourceArc<ComponentInstanceResource>,
+    component_store: &mut wasmtime::Store<ComponentStoreData>,
+    instance: Instance,
     function_name_path: Vec<String>,
     function_params: SavedTerm,
 ) -> SavedTerm {
-    let result = thread_env.run(|env| {
-        let component_store: &mut Store<ComponentStoreData> =
-            &mut (component_store_resource.inner.lock().unwrap());
-        let instance = &mut instance_resource.inner.lock().unwrap();
+    let prepared = thread_env.run(|env| {
+        let given_params = function_params
+            .load(env)
+            .decode::<Vec<Term>>()
+            .map_err(|error| format!("could not load 'function params': {error:?}"))?;
 
-        let given_params = match function_params.load(env).decode::<Vec<Term>>() {
-            Ok(vec) => vec,
-            Err(err) => {
-                return env
-                    .error_tuple(format!("could not load 'function params': {err:?}"))
-                    .encode(env)
-            }
-        };
-
-        // reduce function_name_path to a lookup index by iterating over function_name_path and calling instance.get_export
         let mut lookup_index = None;
         for (index, name) in function_name_path.iter().enumerate() {
             if let Some(inner) = lookup_index {
@@ -267,74 +292,77 @@ fn component_execute_function(
             }
 
             if lookup_index.is_none() {
-                if function_name_path.len() == 1 {
-                    return env
-                        .error_tuple(format!(
-                            "exported function `{}` not found.",
-                            function_name_path.join(", ")
-                        ))
-                        .encode(env);
+                let reason = if function_name_path.len() == 1 {
+                    format!(
+                        "exported function `{}` not found.",
+                        function_name_path.join(", ")
+                    )
                 } else {
-                    return env
-                        .error_tuple(format!(
+                    format!(
                         "exported function `[{}]` not found. Could not find `{}` at position {}",
                         function_name_path.join(", "),
                         name,
                         index
-                    ))
-                        .encode(env);
-                }
+                    )
+                };
+                return Err(reason);
             }
         }
 
-        let lookup_index = match lookup_index {
-            Some(index) => index,
-            None => {
-                return env
-                    .error_tuple(format!(
-                        "exported function `{}` not found.",
-                        function_name_path.join(", ")
-                    ))
-                    .encode(env);
-            }
-        };
+        let lookup_index = lookup_index.ok_or_else(|| {
+            format!(
+                "exported function `{}` not found.",
+                function_name_path.join(", ")
+            )
+        })?;
 
-        let function_result = instance.get_func(&mut *component_store, lookup_index);
-        let function = match function_result {
-            Some(func) => func,
-            None => {
-                return env
-                    .error_tuple(format!(
-                        "exported function `{}` not found",
-                        function_name_path.join(", ")
-                    ))
-                    .encode(env)
-            }
-        };
+        let function = instance
+            .get_func(&mut *component_store, lookup_index)
+            .ok_or_else(|| {
+                format!(
+                    "exported function `{}` not found",
+                    function_name_path.join(", ")
+                )
+            })?;
 
-        let function_type = function.ty(&component_store);
+        let function_type = function.ty(&*component_store);
         let param_types = function_type.params();
         let param_types = param_types.map(|x| x.1.clone()).collect::<Vec<Type>>();
 
-        let converted_params = match convert_params(param_types.as_ref(), given_params) {
-            Ok(params) => params,
-            Err(Error::Term(e)) => {
-                return env.error_tuple(e.encode(env)).encode(env);
-            }
-            Err(e) => {
-                let reason = format!("Error converting param: {e:?}");
-                return env.error_tuple(&reason).encode(env);
-            }
-        };
+        let converted_params =
+            convert_params(param_types.as_ref(), given_params).map_err(|error| match error {
+                Error::Term(value) => {
+                    let value = value.encode(env);
+                    value
+                        .decode::<String>()
+                        .unwrap_or_else(|_| format!("Error converting param: {value:?}"))
+                }
+                error => format!("Error converting param: {error:?}"),
+            })?;
         let results_count = function_type.results().len();
+        Ok::<_, String>((function, converted_params, results_count))
+    });
 
-        let mut result = vec![Val::Bool(false); results_count];
-        match function.call(
+    let (function, converted_params, results_count) = match prepared {
+        Ok(prepared) => prepared,
+        Err(reason) => {
+            let result = thread_env.run(|env| env.error_tuple(reason).encode(env));
+            return thread_env.save(result);
+        }
+    };
+
+    let mut result_values = vec![Val::Bool(false); results_count];
+    let call_result = function
+        .call_async(
             &mut *component_store,
             converted_params.as_slice(),
-            &mut result,
-        ) {
-            Ok(_) => encode_result(env, result),
+            &mut result_values,
+        )
+        .await;
+
+    let result = thread_env.run(|env| {
+        match call_result {
+            Ok(()) => encode_result(env, result_values),
             Err(err) => {
                 let reason = format!("{err}");
                 if let Ok(trap) = err.downcast::<Trap>() {
@@ -355,9 +383,14 @@ fn component_execute_function(
 pub fn receive_callback_result(
     component_resource: ResourceArc<ComponentResource>,
     token_resource: ResourceArc<ComponentCallbackTokenResource>,
-    _success: bool,
+    success: bool,
     result: Term,
 ) -> NifResult<rustler::Atom> {
+    if !success {
+        send_component_callback_result(&token_resource, false, vec![])?;
+        return Ok(atoms::ok());
+    }
+
     let parsed_component = &component_resource.parsed;
     let world = &parsed_component.resolve.worlds[parsed_component.world_id];
     let name = &token_resource.token.name;
@@ -412,25 +445,17 @@ pub fn receive_callback_result(
             })?
     };
 
-    let return_values = token_resource
-        .token
-        .return_values
-        .lock()
-        .map_err(|e| Error::Term(Box::new(format!("Failed to lock return values: {e}"))))?;
-
-    convert_return_values(
-        &component_resource.parsed.resolve,
-        import_function,
-        return_values,
-        result,
-    )
-    .map_err(|e| {
-        Error::Term(Box::new(format!(
-            "Failed to convert imported function return values - {e}"
-        )))
-    })?;
-
-    token_resource.token.continue_signal.notify_one();
+    let return_values =
+        match convert_return_values(&component_resource.parsed.resolve, import_function, result) {
+            Ok(values) => values,
+            Err(error) => {
+                send_component_callback_result(&token_resource, false, vec![])?;
+                return Err(Error::Term(Box::new(format!(
+                    "Failed to convert imported function return values - {error}"
+                ))));
+            }
+        };
+    send_component_callback_result(&token_resource, true, return_values)?;
 
     Ok(atoms::ok())
 }
@@ -438,28 +463,44 @@ pub fn receive_callback_result(
 fn convert_return_values(
     wit_resolver: &Resolve,
     function: &Function,
-    mut return_values: std::sync::MutexGuard<'_, Option<(bool, Vec<Val>)>>,
     result: Term,
-) -> Result<(), String> {
+) -> Result<Vec<Val>, String> {
     if let Some(result_type) = &function.result {
-        let mut vals = Vec::new();
-        vals.push(
-            convert_result_term(result, result_type, wit_resolver, vec![]).map_err(
-                |(msg, path)| {
-                    if path.is_empty() {
-                        msg
-                    } else {
-                        format!("{msg:?} at path: {path:?}")
-                    }
-                },
-            )?,
-        );
-
-        // Set the return values
-        *return_values = Some((true, vals));
+        Ok(vec![convert_result_term(
+            result,
+            result_type,
+            wit_resolver,
+            vec![],
+        )
+        .map_err(|(msg, path)| {
+            if path.is_empty() {
+                msg
+            } else {
+                format!("{msg:?} at path: {path:?}")
+            }
+        })?])
     } else {
-        *return_values = Some((true, vec![]));
+        Ok(vec![])
     }
+}
 
-    Ok(())
+fn send_component_callback_result(
+    token_resource: &ComponentCallbackTokenResource,
+    success: bool,
+    values: Vec<Val>,
+) -> NifResult<()> {
+    let sender = token_resource
+        .token
+        .return_sender
+        .lock()
+        .map_err(|error| {
+            Error::Term(Box::new(format!(
+                "Failed to lock component callback sender: {error}"
+            )))
+        })?
+        .take()
+        .ok_or_else(|| Error::Term(Box::new("Component callback result was already sent")))?;
+    sender
+        .send((success, values))
+        .map_err(|_| Error::Term(Box::new("Component callback is no longer waiting")))
 }

--- a/native/wasmex/src/engine.rs
+++ b/native/wasmex/src/engine.rs
@@ -1,6 +1,7 @@
 use rustler::{Binary, Error, NifStruct, OwnedBinary, Resource, ResourceArc};
 use std::ops::Deref;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, Weak};
+use std::time::Duration;
 use wasmtime::{Config, Engine, WasmBacktraceDetails};
 
 use crate::atoms;
@@ -35,6 +36,38 @@ impl Resource for EngineResource {}
 
 pub struct EngineResource {
     pub inner: Mutex<Engine>,
+    pub(crate) epoch_ticker: Mutex<EpochTicker>,
+}
+
+struct EpochTickerState {
+    engine: Engine,
+}
+
+#[derive(Clone)]
+pub(crate) struct EpochTicker {
+    _state: Arc<EpochTickerState>,
+}
+
+impl EpochTicker {
+    fn new(engine: Engine) -> Self {
+        let state = Arc::new(EpochTickerState { engine });
+        let weak_state: Weak<EpochTickerState> = Arc::downgrade(&state);
+
+        TOKIO_RUNTIME.spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_millis(10));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                interval.tick().await;
+                let Some(state) = weak_state.upgrade() else {
+                    break;
+                };
+                state.engine.increment_epoch();
+            }
+        });
+
+        Self { _state: state }
+    }
 }
 
 #[rustler::nif(name = "engine_new")]
@@ -43,8 +76,10 @@ pub fn new(
 ) -> Result<ResourceArc<EngineResource>, rustler::Error> {
     let config = engine_config(engine_config_ex);
     let engine = Engine::new(&config).map_err(|err| Error::Term(Box::new(err.to_string())))?;
+    let epoch_ticker = EpochTicker::new(engine.clone());
     let resource = ResourceArc::new(EngineResource {
         inner: Mutex::new(engine),
+        epoch_ticker: Mutex::new(epoch_ticker),
     });
 
     Ok(resource)
@@ -89,8 +124,25 @@ pub(crate) fn engine_config(engine_config: ExEngineConfig) -> Config {
     config.wasm_memory64(engine_config.memory64);
     config.wasm_component_model(engine_config.wasm_component_model);
     config.debug_info(engine_config.debug_info);
+    config.epoch_interruption(true);
 
     config
+}
+
+pub(crate) fn unwrap_engine_and_ticker(
+    engine_resource: ResourceArc<EngineResource>,
+) -> Result<(Engine, EpochTicker), rustler::Error> {
+    let ticker = engine_resource
+        .epoch_ticker
+        .lock()
+        .map_err(|error| {
+            rustler::Error::Term(Box::new(format!(
+                "Could not unlock engine epoch ticker: {error}"
+            )))
+        })?
+        .clone();
+    let engine = unwrap_engine(engine_resource)?;
+    Ok((engine, ticker))
 }
 
 pub(crate) fn unwrap_engine(

--- a/native/wasmex/src/environment.rs
+++ b/native/wasmex/src/environment.rs
@@ -190,11 +190,8 @@ fn link_imported_function(
                         // This will allow Elixir callback to operate on these objects.
                         let callback_context = Term::map_new(env);
 
-                        let memory = memory.map(|memory| {
-                            ResourceArc::new(MemoryResource {
-                                inner: Mutex::new(memory),
-                            })
-                        });
+                        let memory =
+                            memory.map(|memory| ResourceArc::new(MemoryResource { inner: memory }));
                         let callback_context = Term::map_put(
                             callback_context,
                             atoms::memory().encode(env),
@@ -223,7 +220,9 @@ fn link_imported_function(
                             .encode(env)
                     });
 
-                    result.expect("expect no send error");
+                    result.map_err(|_| {
+                        WasmtimeError::msg("could not send callback invocation to Elixir")
+                    })?;
 
                     let result = loop {
                         tokio::select! {
@@ -236,9 +235,11 @@ fn link_imported_function(
                                 match command {
                                     Some(command) => handle_command(&mut caller, command).await,
                                     None => {
-                                        return Err(WasmtimeError::msg(
-                                            "the Elixir callback Caller session closed"
-                                        ));
+                                        break (&mut return_receiver).await.map_err(|_| {
+                                            WasmtimeError::msg(
+                                                "the Elixir callback result channel closed"
+                                            )
+                                        })?;
                                     }
                                 }
                             }

--- a/native/wasmex/src/environment.rs
+++ b/native/wasmex/src/environment.rs
@@ -1,15 +1,17 @@
 use crate::{
     atoms,
-    caller::{remove_caller, set_caller},
-    instance::{map_wasm_values_to_vals, LinkedModule, WasmValue},
+    caller::{handle_command, CallbackSession},
+    instance::{map_wasm_values_to_vals, OwnedLinkedModule, WasmValue},
     memory::MemoryResource,
     store::{StoreData, StoreOrCaller, StoreOrCallerResource},
 };
 use rustler::{
     types::tuple, Atom, Encoder, Error, ListIterator, MapIterator, OwnedEnv, ResourceArc, Term,
 };
-use std::sync::{Condvar, Mutex};
+use std::sync::Mutex;
 use wasmtime::{Caller, Engine, Error as WasmtimeError, FuncType, Linker, Val, ValType};
+
+type CallbackResultSender = tokio::sync::oneshot::Sender<(bool, Vec<WasmValue>)>;
 
 pub struct CallbackTokenResource {
     pub token: CallbackToken,
@@ -19,33 +21,25 @@ pub struct CallbackTokenResource {
 impl rustler::Resource for CallbackTokenResource {}
 
 pub struct CallbackToken {
-    pub continue_signal: Condvar,
     pub return_types: Vec<ValType>,
-    pub return_values: Mutex<Option<(bool, Vec<WasmValue>)>>,
+    pub return_sender: Mutex<Option<CallbackResultSender>>,
 }
 
-pub fn link_modules(
+pub async fn link_modules(
     linker: &mut Linker<StoreData>,
-    store: &mut StoreOrCaller,
-    linked_modules: Vec<LinkedModule>,
-) -> Result<(), Error> {
+    mut store: impl wasmtime::AsContextMut<Data = StoreData>,
+    linked_modules: Vec<OwnedLinkedModule>,
+) -> Result<(), String> {
     for linked_module in linked_modules {
         let module_name = linked_module.name;
-        let module = linked_module.module_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock linked module resource as the mutex was poisoned: {e}"
-            )))
-        })?;
-
-        let instance = linker.instantiate(&mut *store, &module).map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not instantiate linked module: {e}"
-            )))
-        })?;
+        let instance = linker
+            .instantiate_async(&mut store, &linked_module.module)
+            .await
+            .map_err(|e| format!("Could not instantiate linked module: {e}"))?;
 
         linker
-            .instance(&mut *store, &module_name, instance)
-            .map_err(|err| Error::Term(Box::new(err.to_string())))?;
+            .instance(&mut store, &module_name, instance)
+            .map_err(|error| error.to_string())?;
     }
 
     Ok(())
@@ -55,6 +49,7 @@ pub fn link_imports(
     engine: &Engine,
     linker: &mut Linker<StoreData>,
     imports: MapIterator,
+    pid: rustler::LocalPid,
 ) -> Result<(), Error> {
     for (namespace_name, namespace_definition) in imports {
         let namespace_name = namespace_name.decode::<String>()?;
@@ -62,7 +57,7 @@ pub fn link_imports(
 
         for (import_name, import) in definition {
             let import_name = import_name.decode::<String>()?;
-            link_import(engine, linker, &namespace_name, &import_name, import)?;
+            link_import(engine, linker, &namespace_name, &import_name, import, pid)?;
         }
     }
     Ok(())
@@ -74,6 +69,7 @@ fn link_import(
     namespace_name: &str,
     import_name: &str,
     definition: Term,
+    pid: rustler::LocalPid,
 ) -> Result<(), Error> {
     let import_tuple = tuple::get_tuple(definition)?;
 
@@ -90,6 +86,7 @@ fn link_import(
             namespace_name.to_string(),
             import_name.to_string(),
             definition,
+            pid,
         );
     }
 
@@ -102,21 +99,20 @@ fn link_import(
 // Once the imported function is called during Wasm execution, the following happens:
 //
 // 1. the rust wrapper we define here is called
-// 2. it creates a callback token containing a Mutex for storing the call result and a Condvar
+// 2. it creates a callback token containing an async result sender
 // 3. the rust wrapper sends an :invoke_callback message to elixir containing the token and call params
 // 4. the Wasmex module receive that call in elixir-land and executes the actual elixir callback
 // 5. after the callback finished execution, return values are send back to Rust via `receive_callback_result`
-// 6. `receive_callback_result` saves the return values in the callback tokens mutex and signals the condvar,
-//    so that the original wrapper function can continue code execution
+// 6. `receive_callback_result` sends the return values through the token while
+//    the Wasmtime host-function future also services scoped Caller operations.
 fn link_imported_function(
     engine: &Engine,
     linker: &mut Linker<StoreData>,
     namespace_name: String,
     import_name: String,
     definition: Term,
+    pid: rustler::LocalPid,
 ) -> Result<(), Error> {
-    let pid = definition.get_env().pid();
-
     let import_tuple = tuple::get_tuple(definition)?;
 
     let param_term = import_tuple
@@ -138,108 +134,124 @@ fn link_imported_function(
 
     let signature = FuncType::new(engine, params_signature, results_signature.clone());
     linker
-        .func_new(
+        .func_new_async(
             &namespace_name.clone(),
             &import_name.clone(),
             signature,
-            move |mut caller: Caller<'_, StoreData>,
-                  params: &[Val],
-                  results: &mut [Val]|
-                  -> Result<(), WasmtimeError> {
-                let callback_token = ResourceArc::new(CallbackTokenResource {
-                    token: CallbackToken {
-                        continue_signal: Condvar::new(),
-                        return_types: results_signature.clone(),
-                        return_values: Mutex::new(None),
-                    },
-                });
+            move |mut caller: Caller<'_, StoreData>, params: &[Val], results: &mut [Val]| {
+                let namespace_name = namespace_name.clone();
+                let import_name = import_name.clone();
+                let results_signature = results_signature.clone();
+                Box::new(async move {
+                    let (return_sender, mut return_receiver) = tokio::sync::oneshot::channel();
+                    let callback_token = ResourceArc::new(CallbackTokenResource {
+                        token: CallbackToken {
+                            return_types: results_signature.clone(),
+                            return_sender: Mutex::new(Some(return_sender)),
+                        },
+                    });
 
-                let memory = caller
-                    .get_export("memory")
-                    .and_then(|memory| memory.into_memory());
+                    let memory = caller
+                        .get_export("memory")
+                        .and_then(|memory| memory.into_memory());
 
-                let caller_token = set_caller(caller);
+                    let (caller_session, mut caller_commands) =
+                        CallbackSession::new(caller.engine().clone());
 
-                let mut msg_env = OwnedEnv::new();
-                let result = msg_env.send_and_clear(&pid.clone(), |env| {
-                    let mut callback_params: Vec<Term> = Vec::with_capacity(params.len());
-                    for value in params {
-                        callback_params.push(match value {
-                            Val::I32(i) => i.encode(env),
-                            Val::I64(i) => i.encode(env),
-                            Val::F32(i) => f32::from_bits(*i).encode(env),
-                            Val::F64(i) => f64::from_bits(*i).encode(env),
-                            Val::V128(i) => i.as_u128().encode(env),
-                            Val::ExternRef(_) => {
-                                (atoms::error(), "unable_to_convert_extern_ref_type").encode(env)
+                    let mut msg_env = OwnedEnv::new();
+                    let result = msg_env.send_and_clear(&pid.clone(), |env| {
+                        let mut callback_params: Vec<Term> = Vec::with_capacity(params.len());
+                        for value in params {
+                            callback_params.push(match value {
+                                Val::I32(i) => i.encode(env),
+                                Val::I64(i) => i.encode(env),
+                                Val::F32(i) => f32::from_bits(*i).encode(env),
+                                Val::F64(i) => f64::from_bits(*i).encode(env),
+                                Val::V128(i) => i.as_u128().encode(env),
+                                Val::ExternRef(_) => {
+                                    (atoms::error(), "unable_to_convert_extern_ref_type")
+                                        .encode(env)
+                                }
+                                Val::FuncRef(_) => {
+                                    (atoms::error(), "unable_to_convert_func_ref_type").encode(env)
+                                }
+                                Val::AnyRef(_) => {
+                                    (atoms::error(), "unable_to_convert_any_ref_type").encode(env)
+                                }
+                                Val::ExnRef(_) => {
+                                    (atoms::error(), "unable_to_convert_exn_ref_type").encode(env)
+                                }
+                                Val::ContRef(_) => {
+                                    (atoms::error(), "unable_to_convert_cont_ref_type").encode(env)
+                                }
+                            })
+                        }
+                        // Callback context will contain memory (plus maybe globals, tables etc later).
+                        // This will allow Elixir callback to operate on these objects.
+                        let callback_context = Term::map_new(env);
+
+                        let memory = memory.map(|memory| {
+                            ResourceArc::new(MemoryResource {
+                                inner: Mutex::new(memory),
+                            })
+                        });
+                        let callback_context = Term::map_put(
+                            callback_context,
+                            atoms::memory().encode(env),
+                            memory.encode(env),
+                        )
+                        .unwrap();
+
+                        let caller_resource = ResourceArc::new(StoreOrCallerResource {
+                            inner: Mutex::new(StoreOrCaller::Caller(caller_session)),
+                        });
+
+                        let callback_context = Term::map_put(
+                            callback_context,
+                            atoms::caller().encode(env),
+                            caller_resource.encode(env),
+                        )
+                        .unwrap();
+                        (
+                            atoms::invoke_callback(),
+                            namespace_name.clone(),
+                            import_name.clone(),
+                            callback_context,
+                            callback_params,
+                            callback_token.clone(),
+                        )
+                            .encode(env)
+                    });
+
+                    result.expect("expect no send error");
+
+                    let result = loop {
+                        tokio::select! {
+                            result = &mut return_receiver => {
+                                break result.map_err(|_| {
+                                    WasmtimeError::msg("the Elixir callback result channel closed")
+                                })?;
                             }
-                            Val::FuncRef(_) => {
-                                (atoms::error(), "unable_to_convert_func_ref_type").encode(env)
+                            command = caller_commands.recv() => {
+                                match command {
+                                    Some(command) => handle_command(&mut caller, command).await,
+                                    None => {
+                                        return Err(WasmtimeError::msg(
+                                            "the Elixir callback Caller session closed"
+                                        ));
+                                    }
+                                }
                             }
-                            Val::AnyRef(_) => {
-                                (atoms::error(), "unable_to_convert_any_ref_type").encode(env)
-                            }
-                            Val::ExnRef(_) => {
-                                (atoms::error(), "unable_to_convert_exn_ref_type").encode(env)
-                            }
-                            Val::ContRef(_) => {
-                                (atoms::error(), "unable_to_convert_cont_ref_type").encode(env)
-                            }
-                        })
+                        }
+                    };
+
+                    match result {
+                        (true, return_values) => write_results(results, &return_values),
+                        (false, _) => {
+                            Err(WasmtimeError::msg("the elixir callback threw an exception"))
+                        }
                     }
-                    // Callback context will contain memory (plus maybe globals, tables etc later).
-                    // This will allow Elixir callback to operate on these objects.
-                    let callback_context = Term::map_new(env);
-
-                    let memory = memory.map(|memory| {
-                        ResourceArc::new(MemoryResource {
-                            inner: Mutex::new(memory),
-                        })
-                    });
-                    let callback_context = Term::map_put(
-                        callback_context,
-                        atoms::memory().encode(env),
-                        memory.encode(env),
-                    )
-                    .unwrap();
-
-                    let caller_resource = ResourceArc::new(StoreOrCallerResource {
-                        inner: Mutex::new(StoreOrCaller::Caller(caller_token)),
-                    });
-
-                    let callback_context = Term::map_put(
-                        callback_context,
-                        atoms::caller().encode(env),
-                        caller_resource.encode(env),
-                    )
-                    .unwrap();
-                    (
-                        atoms::invoke_callback(),
-                        namespace_name.clone(),
-                        import_name.clone(),
-                        callback_context,
-                        callback_params,
-                        callback_token.clone(),
-                    )
-                        .encode(env)
-                });
-
-                result.expect("expect no send error");
-
-                // Wait for the thread to start up - `receive_callback_result` is responsible for that.
-                let mut result = callback_token.token.return_values.lock().unwrap();
-                while result.is_none() {
-                    result = callback_token.token.continue_signal.wait(result).unwrap();
-                }
-                remove_caller(caller_token);
-
-                let result: &(bool, Vec<WasmValue>) = result
-                    .as_ref()
-                    .expect("expect callback token to contain a result");
-                match result {
-                    (true, return_values) => write_results(results, return_values),
-                    (false, _) => Err(WasmtimeError::msg("the elixir callback threw an exception")),
-                }
+                })
             },
         )
         .map_err(|err| Error::Term(Box::new(err.to_string())))?;

--- a/native/wasmex/src/functions.rs
+++ b/native/wasmex/src/functions.rs
@@ -1,12 +1,9 @@
-use wasmtime::Func;
-use wasmtime::Instance;
+use wasmtime::{AsContextMut, Func, Instance};
 
-use crate::store::StoreOrCaller;
-
-pub fn exists(instance: &Instance, store_or_caller: &mut StoreOrCaller, name: &str) -> bool {
+pub fn exists(instance: &Instance, store_or_caller: impl AsContextMut, name: &str) -> bool {
     find(instance, store_or_caller, name).is_some()
 }
 
-pub fn find(instance: &Instance, store_or_caller: &mut StoreOrCaller, name: &str) -> Option<Func> {
+pub fn find(instance: &Instance, store_or_caller: impl AsContextMut, name: &str) -> Option<Func> {
     instance.get_func(store_or_caller, name)
 }

--- a/native/wasmex/src/instance.rs
+++ b/native/wasmex/src/instance.rs
@@ -3,13 +3,14 @@
 #![allow(clippy::needless_borrows_for_generic_args)]
 
 use crate::{
-    async_reply::{send_saved_term, submit_error, AsyncReply},
+    async_reply::{submit_error, AsyncReply},
     atoms,
     environment::{link_imports, link_modules, CallbackTokenResource},
     functions,
     module::ModuleResource,
     printable_term_type::PrintableTermType,
     store::{StoreData, StoreOrCallerResource, StoreTarget},
+    store_executor::with_deadline,
 };
 use rustler::{
     env::SavedTerm,
@@ -17,7 +18,6 @@ use rustler::{
     Encoder, Env, Error, MapIterator, NifMap, NifResult, OwnedEnv, ResourceArc, Term, TermType,
 };
 use std::ops::Deref;
-use std::sync::Mutex;
 use wasmtime::{Instance, Linker, Module, Trap, Val, ValType};
 
 #[derive(NifMap)]
@@ -32,7 +32,7 @@ pub struct OwnedLinkedModule {
 }
 
 pub struct InstanceResource {
-    pub inner: Mutex<Instance>,
+    pub inner: Instance,
 }
 
 #[rustler::resource_impl()]
@@ -85,11 +85,11 @@ pub fn new(
     let callback_pid = imports.get_env().pid();
     let term_env = OwnedEnv::new();
     let imports = term_env.save(imports);
-    let reply = AsyncReply::new(from);
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |mut store| async move {
                 match instantiate(
                     &mut store,
@@ -118,10 +118,8 @@ pub fn new(
                 imports,
                 reply,
             };
-            if let Err(crate::caller::CallerCommand::NewInstance { reply, .. }) =
-                session.submit(command)
-            {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }
@@ -150,11 +148,7 @@ pub(crate) async fn instantiate(
     linker
         .instantiate_async(&mut store, &module)
         .await
-        .map(|instance| {
-            ResourceArc::new(InstanceResource {
-                inner: Mutex::new(instance),
-            })
-        })
+        .map(|instance| ResourceArc::new(InstanceResource { inner: instance }))
         .map_err(|error| error.to_string())
 }
 
@@ -184,16 +178,12 @@ pub fn get_global_value(
     global_name: String,
     from: Term,
 ) -> NifResult<rustler::Atom> {
-    let instance: Instance = *(instance_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!(
-            "Could not unlock instance resource as the mutex was poisoned: {e}"
-        )))
-    })?);
-    let reply = AsyncReply::new(from);
+    let instance = instance_resource.inner;
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |mut store| async move {
                 match instance
                     .get_global(&mut store, &global_name)
@@ -214,10 +204,8 @@ pub fn get_global_value(
                 name: global_name,
                 reply,
             };
-            if let Err(crate::caller::CallerCommand::GetGlobal { reply, .. }) =
-                session.submit(command)
-            {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }
@@ -232,18 +220,14 @@ pub fn set_global_value(
     new_value: Term,
     from: Term,
 ) -> NifResult<rustler::Atom> {
-    let instance: Instance = *(instance_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!(
-            "Could not unlock instance resource as the mutex was poisoned: {e}"
-        )))
-    })?);
+    let instance = instance_resource.inner;
     let term_env = OwnedEnv::new();
     let new_value = term_env.save(new_value);
-    let reply = AsyncReply::new(from);
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |mut store| async move {
                 let result = term_env.run(|env| {
                     let term = new_value.load(env);
@@ -281,10 +265,8 @@ pub fn set_global_value(
                 value: new_value,
                 reply,
             };
-            if let Err(crate::caller::CallerCommand::SetGlobal { reply, .. }) =
-                session.submit(command)
-            {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }
@@ -298,15 +280,11 @@ pub fn function_export_exists(
     function_name: String,
     from: Term,
 ) -> NifResult<rustler::Atom> {
-    let instance: Instance = *(instance_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!(
-            "Could not unlock instance resource as the mutex was poisoned: {e}"
-        )))
-    })?);
-    let reply = AsyncReply::new(from);
+    let instance = instance_resource.inner;
+    let reply = AsyncReply::new(from)?;
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |mut store| async move {
                 reply.send(functions::exists(&instance, &mut store, &function_name));
                 store
@@ -320,10 +298,8 @@ pub fn function_export_exists(
                 name: function_name,
                 reply,
             };
-            if let Err(crate::caller::CallerCommand::FunctionExists { reply, .. }) =
-                session.submit(command)
-            {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }
@@ -353,31 +329,24 @@ pub fn call_exported_function(
     params: Term,
     from: Term,
     timeout_ms: Option<u64>,
-) -> rustler::Atom {
-    let target = match store_or_caller_resource.target() {
-        Ok(target) => target,
-        Err(error) => {
-            AsyncReply::new(from).send_error(format!("{error:?}"));
-            return atoms::ok();
-        }
-    };
+) -> NifResult<rustler::Atom> {
+    let reply = AsyncReply::new(from)?;
+    let target = store_or_caller_resource.target()?;
 
     if let StoreTarget::Caller(session) = target {
         let env = OwnedEnv::new();
         let params = env.save(params);
-        let saved_from = env.save(from);
-        let submit_reply = AsyncReply::new(from);
         let command = crate::caller::CallerCommand::CallExported {
-            instance: *instance_resource.inner.lock().unwrap(),
+            instance: instance_resource.inner,
             function_name,
             env,
             params,
-            from: saved_from,
+            reply,
         };
-        if session.submit(command).is_err() {
-            submit_reply.send_error("Caller is no longer valid");
+        if let Err(error) = session.submit(command) {
+            error.reject();
         }
-        return atoms::ok();
+        return Ok(atoms::ok());
     }
     let StoreTarget::Executor(executor) = target else {
         unreachable!()
@@ -388,10 +357,10 @@ pub fn call_exported_function(
 
     let mut thread_env = OwnedEnv::new();
     let function_params = thread_env.save(params);
-    let saved_from = thread_env.save(from);
-    let submit_reply = AsyncReply::new(from);
+    let submit_reply = AsyncReply::new(from)?;
 
     if let Err(error) = executor.submit(move |mut store| async move {
+        let interrupt_requested = store.data().interrupt_requested.clone();
         let result = execute_function(
             &mut thread_env,
             &mut store,
@@ -399,19 +368,16 @@ pub fn call_exported_function(
             function_name,
             function_params,
         );
-        let result = match deadline {
-            Some(deadline) => tokio::time::timeout_at(deadline, result).await.ok(),
-            None => Some(result.await),
-        };
+        let result = with_deadline(interrupt_requested, deadline, result).await;
         if let Some(result) = result {
-            send_saved_term(thread_env, saved_from, result);
+            reply.send_saved(thread_env, result);
         }
         store
     }) {
         submit_error(submit_reply, error);
     }
 
-    atoms::ok()
+    Ok(atoms::ok())
 }
 
 async fn execute_function(
@@ -426,7 +392,7 @@ async fn execute_function(
             .load(env)
             .decode::<Vec<Term>>()
             .map_err(|_| "could not load 'function params'".to_string())?;
-        let instance: Instance = *(instance_resource.deref().inner.lock().unwrap());
+        let instance = instance_resource.deref().inner;
         let function = functions::find(&instance, &mut *store, &function_name)
             .ok_or_else(|| format!("exported function `{function_name}` not found"))?;
         let function_params = decode_function_param_terms(
@@ -639,16 +605,24 @@ pub fn receive_callback_result(
         let return_types = token_resource.token.return_types.clone();
         match decode_function_param_terms(&return_types, result_list.collect()) {
             Ok(v) => v,
-            Err(reason) => {
-                return Err(Error::Term(Box::new(format!(
-                    "could not convert callback result param to expected return signature: {reason}"
-                ))));
+            Err(_) => {
+                send_callback_result(&token_resource, false, vec![])?;
+                return Ok(atoms::ok());
             }
         }
     } else {
         vec![]
     };
 
+    send_callback_result(&token_resource, success, results)?;
+    Ok(atoms::ok())
+}
+
+fn send_callback_result(
+    token_resource: &CallbackTokenResource,
+    success: bool,
+    results: Vec<WasmValue>,
+) -> NifResult<()> {
     let sender = token_resource
         .token
         .return_sender
@@ -660,9 +634,6 @@ pub fn receive_callback_result(
         })?
         .take()
         .ok_or_else(|| Error::Term(Box::new("Callback result was already sent")))?;
-    sender
-        .send((success, results))
-        .map_err(|_| Error::Term(Box::new("Callback is no longer waiting for a result")))?;
-
-    Ok(atoms::ok())
+    let _ = sender.send((success, results));
+    Ok(())
 }

--- a/native/wasmex/src/instance.rs
+++ b/native/wasmex/src/instance.rs
@@ -3,17 +3,17 @@
 #![allow(clippy::needless_borrows_for_generic_args)]
 
 use crate::{
+    async_reply::{send_saved_term, submit_error, AsyncReply},
     atoms,
-    engine::TOKIO_RUNTIME,
     environment::{link_imports, link_modules, CallbackTokenResource},
     functions,
     module::ModuleResource,
     printable_term_type::PrintableTermType,
-    store::{StoreData, StoreOrCaller, StoreOrCallerResource},
+    store::{StoreData, StoreOrCallerResource, StoreTarget},
 };
 use rustler::{
     env::SavedTerm,
-    types::{tuple::make_tuple, ListIterator, LocalPid},
+    types::{tuple::make_tuple, ListIterator},
     Encoder, Env, Error, MapIterator, NifMap, NifResult, OwnedEnv, ResourceArc, Term, TermType,
 };
 use std::ops::Deref;
@@ -24,6 +24,11 @@ use wasmtime::{Instance, Linker, Module, Trap, Val, ValType};
 pub struct LinkedModule {
     pub name: String,
     pub module_resource: ResourceArc<ModuleResource>,
+}
+
+pub struct OwnedLinkedModule {
+    pub name: String,
+    pub module: Module,
 }
 
 pub struct InstanceResource {
@@ -44,102 +49,179 @@ impl rustler::Resource for InstanceResource {}
 pub fn new(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     module_resource: ResourceArc<ModuleResource>,
-    imports: MapIterator,
+    imports: Term,
     linked_modules: Vec<LinkedModule>,
-) -> Result<ResourceArc<InstanceResource>, rustler::Error> {
-    let module = module_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!(
-            "Could not unlock module resource as the mutex was poisoned: {e}"
-        )))
-    })?;
-    let store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
+    from: Term,
+) -> Result<rustler::Atom, rustler::Error> {
+    let module = module_resource
+        .inner
+        .lock()
+        .map_err(|e| {
             rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource as the mutex was poisoned: {e}"
+                "Could not unlock module resource as the mutex was poisoned: {e}"
             )))
-        })?);
+        })?
+        .clone();
+    let linked_modules = linked_modules
+        .into_iter()
+        .map(|linked_module| {
+            let module = linked_module
+                .module_resource
+                .inner
+                .lock()
+                .map_err(|error| {
+                    rustler::Error::Term(Box::new(format!(
+                        "Could not unlock linked module resource: {error}"
+                    )))
+                })?
+                .clone();
+            Ok(OwnedLinkedModule {
+                name: linked_module.name,
+                module,
+            })
+        })
+        .collect::<Result<Vec<_>, rustler::Error>>()?;
 
-    let instance = link_and_create_instance(store_or_caller, &module, imports, linked_modules)?;
-    let resource = ResourceArc::new(InstanceResource {
-        inner: Mutex::new(instance),
-    });
-    Ok(resource)
+    let callback_pid = imports.get_env().pid();
+    let term_env = OwnedEnv::new();
+    let imports = term_env.save(imports);
+    let reply = AsyncReply::new(from);
+
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |mut store| async move {
+                match instantiate(
+                    &mut store,
+                    module,
+                    linked_modules,
+                    callback_pid,
+                    term_env,
+                    imports,
+                )
+                .await
+                {
+                    Ok(instance) => reply.send(instance),
+                    Err(error) => reply.send_error(error),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = crate::caller::CallerCommand::NewInstance {
+                module,
+                linked_modules,
+                callback_pid,
+                env: term_env,
+                imports,
+                reply,
+            };
+            if let Err(crate::caller::CallerCommand::NewInstance { reply, .. }) =
+                session.submit(command)
+            {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
+    }
+
+    Ok(atoms::ok())
 }
 
-fn link_and_create_instance(
-    store_or_caller: &mut StoreOrCaller,
-    module: &Module,
+pub(crate) async fn instantiate(
+    mut store: impl wasmtime::AsContextMut<Data = StoreData>,
+    module: Module,
+    linked_modules: Vec<OwnedLinkedModule>,
+    callback_pid: rustler::LocalPid,
+    term_env: OwnedEnv,
+    imports: SavedTerm,
+) -> Result<ResourceArc<InstanceResource>, String> {
+    let mut linker = term_env
+        .run(|env| {
+            let imports = imports.load(env).decode::<MapIterator>()?;
+            create_linker(&store, imports, callback_pid)
+        })
+        .map_err(|error| format!("{error:?}"))?;
+
+    link_modules(&mut linker, &mut store, linked_modules)
+        .await
+        .map_err(|error| format!("{error:?}"))?;
+    linker
+        .instantiate_async(&mut store, &module)
+        .await
+        .map(|instance| {
+            ResourceArc::new(InstanceResource {
+                inner: Mutex::new(instance),
+            })
+        })
+        .map_err(|error| error.to_string())
+}
+
+fn create_linker(
+    store: impl wasmtime::AsContext<Data = StoreData>,
     imports: MapIterator,
-    linked_modules: Vec<LinkedModule>,
-) -> Result<Instance, Error> {
-    let mut linker = Linker::new(store_or_caller.engine());
-    if let Some(_wasi_ctx) = &store_or_caller.data().wasi {
+    callback_pid: rustler::LocalPid,
+) -> Result<Linker<StoreData>, Error> {
+    let store = store.as_context();
+    let mut linker = Linker::new(store.engine());
+    if store.data().wasi.is_some() {
         linker.allow_shadowing(true);
-        wasmtime_wasi::p1::add_to_linker_sync(&mut linker, |s: &mut StoreData| {
+        wasmtime_wasi::p1::add_to_linker_async(&mut linker, |s: &mut StoreData| {
             s.wasi.as_mut().unwrap()
         })
         .map_err(|err| Error::Term(Box::new(err.to_string())))?;
     }
 
-    link_imports(store_or_caller.engine(), &mut linker, imports)?;
-    link_modules(&mut linker, store_or_caller, linked_modules)?;
-
-    linker
-        .instantiate(store_or_caller, module)
-        .map_err(|err| Error::Term(Box::new(err.to_string())))
+    link_imports(store.engine(), &mut linker, imports, callback_pid)?;
+    Ok(linker)
 }
 
 #[rustler::nif(name = "instance_get_global_value")]
 pub fn get_global_value(
-    env: rustler::Env,
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     instance_resource: ResourceArc<InstanceResource>,
     global_name: String,
-) -> NifResult<Term> {
+    from: Term,
+) -> NifResult<rustler::Atom> {
     let instance: Instance = *(instance_resource.inner.lock().map_err(|e| {
         rustler::Error::Term(Box::new(format!(
             "Could not unlock instance resource as the mutex was poisoned: {e}"
         )))
     })?);
-    let mut store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock instance/store resource as the mutex was poisoned: {e}"
-            )))
-        })?);
+    let reply = AsyncReply::new(from);
 
-    let global = instance
-        .get_global(&mut store_or_caller, &global_name)
-        .ok_or_else(|| {
-            rustler::Error::Term(Box::new(format!(
-                "exported global `{global_name}` not found"
-            )))
-        })?;
-
-    let value = global.get(store_or_caller);
-
-    match value {
-        Val::I32(i) => Ok(i.encode(env)),
-        Val::I64(i) => Ok(i.encode(env)),
-        Val::F32(i) => Ok(f32::from_bits(i).encode(env)),
-        Val::F64(i) => Ok(f64::from_bits(i).encode(env)),
-        Val::V128(i) => Ok(rustler::BigInt::from(i.as_u128()).encode(env)),
-        Val::FuncRef(_) => Err(rustler::Error::Term(Box::new(
-            "unable_to_return_func_ref_type",
-        ))),
-        Val::ExternRef(_) => Err(rustler::Error::Term(Box::new(
-            "unable_to_return_extern_ref_type",
-        ))),
-        Val::AnyRef(_) => Err(rustler::Error::Term(Box::new(
-            "unable_to_return_any_ref_type",
-        ))),
-        Val::ExnRef(_) => Err(rustler::Error::Term(Box::new(
-            "unable_to_return_exn_ref_type",
-        ))),
-        Val::ContRef(_) => Err(rustler::Error::Term(Box::new(
-            "unable_to_return_cont_ref_type",
-        ))),
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |mut store| async move {
+                match instance
+                    .get_global(&mut store, &global_name)
+                    .ok_or_else(|| format!("exported global `{global_name}` not found"))
+                    .map(|global| global.get(&mut store))
+                {
+                    Ok(value) => send_global_value(reply, value),
+                    Err(error) => reply.send_error(error),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = crate::caller::CallerCommand::GetGlobal {
+                instance,
+                name: global_name,
+                reply,
+            };
+            if let Err(crate::caller::CallerCommand::GetGlobal { reply, .. }) =
+                session.submit(command)
+            {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
     }
+    Ok(atoms::ok())
 }
 
 #[rustler::nif(name = "instance_set_global_value")]
@@ -148,48 +230,65 @@ pub fn set_global_value(
     instance_resource: ResourceArc<InstanceResource>,
     global_name: String,
     new_value: Term,
-) -> NifResult<()> {
+    from: Term,
+) -> NifResult<rustler::Atom> {
     let instance: Instance = *(instance_resource.inner.lock().map_err(|e| {
         rustler::Error::Term(Box::new(format!(
             "Could not unlock instance resource as the mutex was poisoned: {e}"
         )))
     })?);
-    let mut store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock instance/store resource as the mutex was poisoned: {e}"
-            )))
-        })?);
+    let term_env = OwnedEnv::new();
+    let new_value = term_env.save(new_value);
+    let reply = AsyncReply::new(from);
 
-    let global = instance
-        .get_global(&mut store_or_caller, &global_name)
-        .ok_or_else(|| {
-            rustler::Error::Term(Box::new(format!(
-                "exported global `{global_name}` not found"
-            )))
-        })?;
-
-    let global_type = global.ty(&store_or_caller).content().clone();
-
-    let new_value = decode_term_as_wasm_value(global_type.clone(), new_value).ok_or_else(|| {
-        rustler::Error::Term(Box::new(format!(
-            "Cannot convert to a WebAssembly {:?} value. Given `{:?}`.",
-            global_type,
-            PrintableTermType::PrintTerm(new_value.get_type())
-        )))
-    })?;
-
-    let val: Val = match new_value {
-        WasmValue::I32(value) => value.into(),
-        WasmValue::I64(value) => value.into(),
-        WasmValue::F32(value) => value.into(),
-        WasmValue::F64(value) => value.into(),
-        WasmValue::V128(value) => value.into(),
-    };
-
-    global
-        .set(store_or_caller, val)
-        .map_err(|e| rustler::Error::Term(Box::new(format!("Could not set global: {e}"))))
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |mut store| async move {
+                let result = term_env.run(|env| {
+                    let term = new_value.load(env);
+                    let global = instance
+                        .get_global(&mut store, &global_name)
+                        .ok_or_else(|| format!("exported global `{global_name}` not found"))?;
+                    let global_type = global.ty(&store).content().clone();
+                    let value =
+                        decode_term_as_wasm_value(global_type.clone(), term).ok_or_else(|| {
+                            format!(
+                                "Cannot convert to a WebAssembly {:?} value. Given `{:?}`.",
+                                global_type,
+                                PrintableTermType::PrintTerm(term.get_type())
+                            )
+                        })?;
+                    let value = map_wasm_values_to_vals(&[value]).remove(0);
+                    global
+                        .set(&mut store, value)
+                        .map_err(|error| format!("Could not set global: {error}"))
+                });
+                match result {
+                    Ok(()) => reply.send(()),
+                    Err(error) => reply.send_error(error),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = crate::caller::CallerCommand::SetGlobal {
+                instance,
+                name: global_name,
+                env: term_env,
+                value: new_value,
+                reply,
+            };
+            if let Err(crate::caller::CallerCommand::SetGlobal { reply, .. }) =
+                session.submit(command)
+            {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
+    }
+    Ok(atoms::ok())
 }
 
 #[rustler::nif(name = "instance_function_export_exists")]
@@ -197,21 +296,53 @@ pub fn function_export_exists(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     instance_resource: ResourceArc<InstanceResource>,
     function_name: String,
-) -> NifResult<bool> {
+    from: Term,
+) -> NifResult<rustler::Atom> {
     let instance: Instance = *(instance_resource.inner.lock().map_err(|e| {
         rustler::Error::Term(Box::new(format!(
             "Could not unlock instance resource as the mutex was poisoned: {e}"
         )))
     })?);
-    let store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock instance/store resource as the mutex was poisoned: {e}"
-            )))
-        })?);
+    let reply = AsyncReply::new(from);
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |mut store| async move {
+                reply.send(functions::exists(&instance, &mut store, &function_name));
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = crate::caller::CallerCommand::FunctionExists {
+                instance,
+                name: function_name,
+                reply,
+            };
+            if let Err(crate::caller::CallerCommand::FunctionExists { reply, .. }) =
+                session.submit(command)
+            {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
+    }
+    Ok(atoms::ok())
+}
 
-    let result = functions::exists(&instance, store_or_caller, &function_name);
-    Ok(result)
+pub(crate) fn send_global_value(reply: AsyncReply, value: Val) {
+    match value {
+        Val::I32(value) => reply.send(value),
+        Val::I64(value) => reply.send(value),
+        Val::F32(value) => reply.send(f32::from_bits(value)),
+        Val::F64(value) => reply.send(f64::from_bits(value)),
+        Val::V128(value) => reply.send(rustler::BigInt::from(value.as_u128())),
+        Val::FuncRef(_) => reply.send_error("unable_to_return_func_ref_type"),
+        Val::ExternRef(_) => reply.send_error("unable_to_return_extern_ref_type"),
+        Val::AnyRef(_) => reply.send_error("unable_to_return_any_ref_type"),
+        Val::ExnRef(_) => reply.send_error("unable_to_return_exn_ref_type"),
+        Val::ContRef(_) => reply.send_error("unable_to_return_cont_ref_type"),
+    }
 }
 
 #[rustler::nif(name = "instance_call_exported_function")]
@@ -221,89 +352,106 @@ pub fn call_exported_function(
     function_name: String,
     params: Term,
     from: Term,
+    timeout_ms: Option<u64>,
 ) -> rustler::Atom {
-    // create erlang environment for the thread
-    let mut thread_env = OwnedEnv::new();
-    // copy over params into the thread environment
-    let function_params = thread_env.save(params);
-    let from = thread_env.save(from);
+    let target = match store_or_caller_resource.target() {
+        Ok(target) => target,
+        Err(error) => {
+            AsyncReply::new(from).send_error(format!("{error:?}"));
+            return atoms::ok();
+        }
+    };
 
-    TOKIO_RUNTIME.spawn_blocking(move || {
-        // Execute function and get the result
+    if let StoreTarget::Caller(session) = target {
+        let env = OwnedEnv::new();
+        let params = env.save(params);
+        let saved_from = env.save(from);
+        let submit_reply = AsyncReply::new(from);
+        let command = crate::caller::CallerCommand::CallExported {
+            instance: *instance_resource.inner.lock().unwrap(),
+            function_name,
+            env,
+            params,
+            from: saved_from,
+        };
+        if session.submit(command).is_err() {
+            submit_reply.send_error("Caller is no longer valid");
+        }
+        return atoms::ok();
+    }
+    let StoreTarget::Executor(executor) = target else {
+        unreachable!()
+    };
+
+    let deadline = timeout_ms
+        .map(|timeout| tokio::time::Instant::now() + std::time::Duration::from_millis(timeout));
+
+    let mut thread_env = OwnedEnv::new();
+    let function_params = thread_env.save(params);
+    let saved_from = thread_env.save(from);
+    let submit_reply = AsyncReply::new(from);
+
+    if let Err(error) = executor.submit(move |mut store| async move {
         let result = execute_function(
             &mut thread_env,
-            store_or_caller_resource,
+            &mut store,
             instance_resource,
             function_name,
             function_params,
         );
-
-        // Send GenServer reply directly to the caller
-        thread_env.run(|env| {
-            let from_tuple = from.load(env).decode::<Term>().unwrap();
-            let result_term = result
-                .load(env)
-                .decode::<Term>()
-                .unwrap_or(atoms::error().encode(env));
-
-            // GenServer.call from tuple is {pid, ref}
-            let (caller_pid, ref_term) = from_tuple
-                .decode::<(LocalPid, Term)>()
-                .expect("from must be a GenServer {pid, ref} tuple");
-
-            // Send GenServer reply format directly to caller: {ref, result}
-            let _ = env.send(&caller_pid, make_tuple(env, &[ref_term, result_term]));
-        });
-    });
+        let result = match deadline {
+            Some(deadline) => tokio::time::timeout_at(deadline, result).await.ok(),
+            None => Some(result.await),
+        };
+        if let Some(result) = result {
+            send_saved_term(thread_env, saved_from, result);
+        }
+        store
+    }) {
+        submit_error(submit_reply, error);
+    }
 
     atoms::ok()
 }
 
-fn execute_function(
+async fn execute_function(
     thread_env: &mut OwnedEnv,
-    store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
+    store: &mut wasmtime::Store<StoreData>,
     instance_resource: ResourceArc<InstanceResource>,
     function_name: String,
     function_params: SavedTerm,
 ) -> SavedTerm {
-    let result = thread_env.run(|env: Env| {
-        let given_params = match function_params.load(env).decode::<Vec<Term>>() {
-            Ok(vec) => vec,
-            Err(_) => {
-                return env
-                    .error_tuple("could not load 'function params'")
-                    .encode(env)
-            }
-        };
+    let prepared = thread_env.run(|env: Env| {
+        let given_params = function_params
+            .load(env)
+            .decode::<Vec<Term>>()
+            .map_err(|_| "could not load 'function params'".to_string())?;
         let instance: Instance = *(instance_resource.deref().inner.lock().unwrap());
-        let mut store_or_caller = store_or_caller_resource.deref().inner.lock().unwrap();
-        let function_result = functions::find(&instance, &mut store_or_caller, &function_name);
-        let function = match function_result {
-            Some(func) => func,
-            None => {
-                return env
-                    .error_tuple(&format!("exported function `{function_name}` not found"))
-                    .encode(env)
-            }
-        };
-        let function_params_result = decode_function_param_terms(
-            &function
-                .ty(&*store_or_caller)
-                .params()
-                .collect::<Vec<ValType>>(),
+        let function = functions::find(&instance, &mut *store, &function_name)
+            .ok_or_else(|| format!("exported function `{function_name}` not found"))?;
+        let function_params = decode_function_param_terms(
+            &function.ty(&*store).params().collect::<Vec<ValType>>(),
             given_params,
-        );
-        let function_params = match function_params_result {
-            Ok(vec) => map_wasm_values_to_vals(&vec),
-            Err(reason) => return env.error_tuple(&reason).encode(env),
-        };
-        let results_count = function.ty(&*store_or_caller).results().len();
-        let mut results = vec![Val::null_extern_ref(); results_count];
-        let call_result = function.call(
-            &mut *store_or_caller,
-            function_params.as_slice(),
-            &mut results,
-        );
+        )
+        .map(|values| map_wasm_values_to_vals(&values))?;
+        let results_count = function.ty(&*store).results().len();
+        Ok::<_, String>((function, function_params, results_count))
+    });
+
+    let (function, function_params, results_count) = match prepared {
+        Ok(prepared) => prepared,
+        Err(reason) => {
+            let result = thread_env.run(|env| env.error_tuple(reason).encode(env));
+            return thread_env.save(result);
+        }
+    };
+
+    let mut results = vec![Val::null_extern_ref(); results_count];
+    let call_result = function
+        .call_async(&mut *store, function_params.as_slice(), &mut results)
+        .await;
+
+    let result = thread_env.run(|env: Env| {
         match call_result {
             Ok(_) => (),
             Err(err) => {
@@ -367,7 +515,7 @@ pub enum WasmValue {
     V128(u128),
 }
 
-fn decode_term_as_wasm_value(expected_type: ValType, term: Term) -> Option<WasmValue> {
+pub(crate) fn decode_term_as_wasm_value(expected_type: ValType, term: Term) -> Option<WasmValue> {
     let value = match (expected_type, term.get_type()) {
         (ValType::I32, TermType::Integer | TermType::Float) => match term.decode::<i32>() {
             Ok(value) => WasmValue::I32(value),
@@ -501,9 +649,20 @@ pub fn receive_callback_result(
         vec![]
     };
 
-    let mut result = token_resource.token.return_values.lock().unwrap();
-    *result = Some((success, results));
-    token_resource.token.continue_signal.notify_one();
+    let sender = token_resource
+        .token
+        .return_sender
+        .lock()
+        .map_err(|error| {
+            Error::Term(Box::new(format!(
+                "Could not unlock callback result sender: {error}"
+            )))
+        })?
+        .take()
+        .ok_or_else(|| Error::Term(Box::new("Callback result was already sent")))?;
+    sender
+        .send((success, results))
+        .map_err(|_| Error::Term(Box::new("Callback is no longer waiting for a result")))?;
 
     Ok(atoms::ok())
 }

--- a/native/wasmex/src/lib.rs
+++ b/native/wasmex/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod async_reply;
 pub mod atoms;
 pub mod caller;
 pub mod component;
@@ -12,6 +13,7 @@ pub mod module;
 pub mod pipe;
 pub mod printable_term_type;
 pub mod store;
+pub mod store_executor;
 pub mod wat;
 pub mod wit;
 

--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -8,26 +8,17 @@ use crate::{
     store::{StoreOrCallerResource, StoreTarget},
 };
 use rustler::{Atom, Binary, ResourceArc, Term};
-use std::sync::Mutex;
 use wasmtime::{Instance, Memory};
 
 pub struct MemoryResource {
-    pub inner: Mutex<Memory>,
+    pub inner: Memory,
 }
 
 #[rustler::resource_impl()]
 impl rustler::Resource for MemoryResource {}
 
-fn clone_memory(resource: &MemoryResource) -> Result<Memory, rustler::Error> {
-    resource
-        .inner
-        .lock()
-        .map(|memory| *memory)
-        .map_err(|error| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock memory resource: {error}"
-            )))
-        })
+fn clone_memory(resource: &MemoryResource) -> Memory {
+    resource.inner
 }
 
 #[rustler::nif(name = "memory_from_instance")]
@@ -36,21 +27,15 @@ pub fn from_instance(
     instance_resource: ResourceArc<instance::InstanceResource>,
     from: Term,
 ) -> Result<Atom, rustler::Error> {
-    let instance: Instance = *instance_resource.inner.lock().map_err(|error| {
-        rustler::Error::Term(Box::new(format!(
-            "Could not unlock instance resource: {error}"
-        )))
-    })?;
-    let reply = AsyncReply::new(from);
+    let instance = instance_resource.inner;
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |mut store| async move {
                 match memory_from_instance(&instance, &mut store) {
-                    Ok(memory) => reply.send(ResourceArc::new(MemoryResource {
-                        inner: Mutex::new(memory),
-                    })),
+                    Ok(memory) => reply.send(ResourceArc::new(MemoryResource { inner: memory })),
                     Err(error) => reply.send_error(error),
                 }
                 store
@@ -60,8 +45,8 @@ pub fn from_instance(
         }
         StoreTarget::Caller(session) => {
             let command = CallerCommand::MemoryFromInstance { instance, reply };
-            if let Err(CallerCommand::MemoryFromInstance { reply, .. }) = session.submit(command) {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }
@@ -74,12 +59,12 @@ pub fn size(
     memory_resource: ResourceArc<MemoryResource>,
     from: Term,
 ) -> Result<Atom, rustler::Error> {
-    let memory = clone_memory(&memory_resource)?;
-    let reply = AsyncReply::new(from);
+    let memory = clone_memory(&memory_resource);
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |store| async move {
                 reply.send(memory.data_size(&store));
                 store
@@ -89,8 +74,8 @@ pub fn size(
         }
         StoreTarget::Caller(session) => {
             let command = CallerCommand::MemorySize { memory, reply };
-            if let Err(CallerCommand::MemorySize { reply, .. }) = session.submit(command) {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }
@@ -104,12 +89,12 @@ pub fn grow(
     pages: u64,
     from: Term,
 ) -> Result<Atom, rustler::Error> {
-    let memory = clone_memory(&memory_resource)?;
-    let reply = AsyncReply::new(from);
+    let memory = clone_memory(&memory_resource);
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |mut store| async move {
                 match memory.grow(&mut store, pages) {
                     Ok(old_pages) => reply.send(old_pages),
@@ -132,12 +117,12 @@ pub fn get_byte(
     index: usize,
     from: Term,
 ) -> Result<Atom, rustler::Error> {
-    let memory = clone_memory(&memory_resource)?;
-    let reply = AsyncReply::new(from);
+    let memory = clone_memory(&memory_resource);
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |store| async move {
                 let mut buffer = [0];
                 match memory.read(&store, index, &mut buffer) {
@@ -155,8 +140,8 @@ pub fn get_byte(
                 index,
                 reply,
             };
-            if let Err(CallerCommand::MemoryGetByte { reply, .. }) = session.submit(command) {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }
@@ -171,12 +156,12 @@ pub fn set_byte(
     value: u8,
     from: Term,
 ) -> Result<Atom, rustler::Error> {
-    let memory = clone_memory(&memory_resource)?;
-    let reply = AsyncReply::new(from);
+    let memory = clone_memory(&memory_resource);
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |mut store| async move {
                 match memory.write(&mut store, index, &[value]) {
                     Ok(()) => reply.send(atoms::ok()),
@@ -194,8 +179,8 @@ pub fn set_byte(
                 value,
                 reply,
             };
-            if let Err(CallerCommand::MemorySetByte { reply, .. }) = session.submit(command) {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }
@@ -220,12 +205,12 @@ pub fn read_binary(
     len: usize,
     from: Term,
 ) -> Result<Atom, rustler::Error> {
-    let memory = clone_memory(&memory_resource)?;
-    let reply = AsyncReply::new(from);
+    let memory = clone_memory(&memory_resource);
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |store| async move {
                 let mut buffer = vec![0u8; len];
                 match memory.read(&store, index, &mut buffer) {
@@ -244,8 +229,8 @@ pub fn read_binary(
                 len,
                 reply,
             };
-            if let Err(CallerCommand::MemoryRead { reply, .. }) = session.submit(command) {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }
@@ -260,13 +245,13 @@ pub fn write_binary(
     binary: Binary,
     from: Term,
 ) -> Result<Atom, rustler::Error> {
-    let memory = clone_memory(&memory_resource)?;
+    let memory = clone_memory(&memory_resource);
     let bytes = binary.as_slice().to_vec();
-    let reply = AsyncReply::new(from);
+    let reply = AsyncReply::new(from)?;
 
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |mut store| async move {
                 match memory.write(&mut store, index, &bytes) {
                     Ok(()) => reply.send(atoms::ok()),
@@ -284,8 +269,8 @@ pub fn write_binary(
                 bytes,
                 reply,
             };
-            if let Err(CallerCommand::MemoryWrite { reply, .. }) = session.submit(command) {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(command) {
+                error.reject();
             }
         }
     }

--- a/native/wasmex/src/memory.rs
+++ b/native/wasmex/src/memory.rs
@@ -1,11 +1,15 @@
-//! Memory API of an WebAssembly instance.
+//! Memory API of a WebAssembly instance.
 
-use crate::store::{StoreOrCaller, StoreOrCallerResource};
-use crate::{atoms, instance};
-use rustler::{Atom, Binary, Error, NewBinary, NifResult, ResourceArc, Term};
-use std::io::Write;
+use crate::{
+    async_reply::{submit_error, AsyncReply},
+    atoms,
+    caller::CallerCommand,
+    instance,
+    store::{StoreOrCallerResource, StoreTarget},
+};
+use rustler::{Atom, Binary, ResourceArc, Term};
 use std::sync::Mutex;
-use wasmtime::{Instance, Memory, Store};
+use wasmtime::{Instance, Memory};
 
 pub struct MemoryResource {
     pub inner: Mutex<Memory>,
@@ -14,42 +18,83 @@ pub struct MemoryResource {
 #[rustler::resource_impl()]
 impl rustler::Resource for MemoryResource {}
 
+fn clone_memory(resource: &MemoryResource) -> Result<Memory, rustler::Error> {
+    resource
+        .inner
+        .lock()
+        .map(|memory| *memory)
+        .map_err(|error| {
+            rustler::Error::Term(Box::new(format!(
+                "Could not unlock memory resource: {error}"
+            )))
+        })
+}
+
 #[rustler::nif(name = "memory_from_instance")]
 pub fn from_instance(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     instance_resource: ResourceArc<instance::InstanceResource>,
-) -> Result<ResourceArc<MemoryResource>, rustler::Error> {
-    let instance: Instance = *(instance_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock instance resource: {e}")))
-    })?);
-    let store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource: {e}"
-            )))
-        })?);
-    let memory = memory_from_instance(&instance, store_or_caller)?;
-    let resource = ResourceArc::new(MemoryResource {
-        inner: Mutex::new(memory.to_owned()),
-    });
+    from: Term,
+) -> Result<Atom, rustler::Error> {
+    let instance: Instance = *instance_resource.inner.lock().map_err(|error| {
+        rustler::Error::Term(Box::new(format!(
+            "Could not unlock instance resource: {error}"
+        )))
+    })?;
+    let reply = AsyncReply::new(from);
 
-    Ok(resource)
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |mut store| async move {
+                match memory_from_instance(&instance, &mut store) {
+                    Ok(memory) => reply.send(ResourceArc::new(MemoryResource {
+                        inner: Mutex::new(memory),
+                    })),
+                    Err(error) => reply.send_error(error),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = CallerCommand::MemoryFromInstance { instance, reply };
+            if let Err(CallerCommand::MemoryFromInstance { reply, .. }) = session.submit(command) {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
+    }
+    Ok(atoms::ok())
 }
 
 #[rustler::nif(name = "memory_size")]
 pub fn size(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     memory_resource: ResourceArc<MemoryResource>,
-) -> NifResult<usize> {
-    let store_or_caller: &StoreOrCaller =
-        &*(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
-        })?);
-    let memory = memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
-    })?;
-    let length = memory.data_size(store_or_caller);
-    Ok(length)
+    from: Term,
+) -> Result<Atom, rustler::Error> {
+    let memory = clone_memory(&memory_resource)?;
+    let reply = AsyncReply::new(from);
+
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |store| async move {
+                reply.send(memory.data_size(&store));
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = CallerCommand::MemorySize { memory, reply };
+            if let Err(CallerCommand::MemorySize { reply, .. }) = session.submit(command) {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
+    }
+    Ok(atoms::ok())
 }
 
 #[rustler::nif(name = "memory_grow")]
@@ -57,35 +102,27 @@ pub fn grow(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     memory_resource: ResourceArc<MemoryResource>,
     pages: u64,
-) -> NifResult<u64> {
-    let store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource: {e}"
-            )))
-        })?);
-    let memory = memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
-    })?;
-    let store = match store_or_caller {
-        StoreOrCaller::Store(store) => store,
-        StoreOrCaller::Caller(_) => {
-            return Err(Error::Term(Box::new("Cannot grow memory from caller")))
-        }
-    };
-    let old_pages = grow_by_pages(&memory, store, pages)?;
-    Ok(old_pages)
-}
+    from: Term,
+) -> Result<Atom, rustler::Error> {
+    let memory = clone_memory(&memory_resource)?;
+    let reply = AsyncReply::new(from);
 
-/// Grows the memory by the given amount of pages. Returns the old page count.
-fn grow_by_pages<T>(
-    memory: &Memory,
-    store: &mut Store<T>,
-    number_of_pages: u64,
-) -> Result<u64, Error> {
-    memory
-        .grow(store, number_of_pages)
-        .map_err(|err| Error::Term(Box::new(format!("Failed to grow the memory: {err}."))))
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |mut store| async move {
+                match memory.grow(&mut store, pages) {
+                    Ok(old_pages) => reply.send(old_pages),
+                    Err(error) => reply.send_error(format!("Failed to grow the memory: {error}.")),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(_) => reply.send_error("Cannot grow memory from caller"),
+    }
+    Ok(atoms::ok())
 }
 
 #[rustler::nif(name = "memory_get_byte")]
@@ -93,20 +130,37 @@ pub fn get_byte(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     memory_resource: ResourceArc<MemoryResource>,
     index: usize,
-) -> NifResult<u8> {
-    let store_or_caller = &*(store_or_caller_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
-    })?);
-    let memory: &Memory = &*(memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
-    })?);
+    from: Term,
+) -> Result<Atom, rustler::Error> {
+    let memory = clone_memory(&memory_resource)?;
+    let reply = AsyncReply::new(from);
 
-    let mut buffer = [0];
-    memory
-        .read(store_or_caller, index, &mut buffer)
-        .map_err(|err| Error::Term(Box::new(err.to_string())))?;
-
-    Ok(buffer[0])
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |store| async move {
+                let mut buffer = [0];
+                match memory.read(&store, index, &mut buffer) {
+                    Ok(()) => reply.send(buffer[0]),
+                    Err(error) => reply.send_error(error.to_string()),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = CallerCommand::MemoryGetByte {
+                memory,
+                index,
+                reply,
+            };
+            if let Err(CallerCommand::MemoryGetByte { reply, .. }) = session.submit(command) {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
+    }
+    Ok(atoms::ok())
 }
 
 #[rustler::nif(name = "memory_set_byte")]
@@ -114,80 +168,126 @@ pub fn set_byte(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     memory_resource: ResourceArc<MemoryResource>,
     index: usize,
-    value: Term,
-) -> NifResult<Atom> {
-    let store_or_caller = &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
-    })?);
-    let memory: &Memory = &*(memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
-    })?);
-    let value = value.decode()?;
-    memory
-        .write(store_or_caller, index, &[value])
-        .map_err(|err| Error::Term(Box::new(err.to_string())))?;
+    value: u8,
+    from: Term,
+) -> Result<Atom, rustler::Error> {
+    let memory = clone_memory(&memory_resource)?;
+    let reply = AsyncReply::new(from);
 
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |mut store| async move {
+                match memory.write(&mut store, index, &[value]) {
+                    Ok(()) => reply.send(atoms::ok()),
+                    Err(error) => reply.send_error(error.to_string()),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = CallerCommand::MemorySetByte {
+                memory,
+                index,
+                value,
+                reply,
+            };
+            if let Err(CallerCommand::MemorySetByte { reply, .. }) = session.submit(command) {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
+    }
     Ok(atoms::ok())
 }
 
-pub fn memory_from_instance(
+pub fn memory_from_instance<T: wasmtime::AsContextMut>(
     instance: &Instance,
-    store_or_caller: &mut StoreOrCaller,
-) -> Result<Memory, Error> {
+    mut store: T,
+) -> Result<Memory, String> {
     instance
-        .exports(store_or_caller)
+        .exports(&mut store)
         .find_map(|export| export.into_memory())
-        .ok_or_else(|| Error::Term(Box::new("The WebAssembly module has no exported memory.")))
+        .ok_or_else(|| "The WebAssembly module has no exported memory.".to_string())
 }
 
-#[rustler::nif(name = "memory_read_binary", schedule = "DirtyCpu")]
+#[rustler::nif(name = "memory_read_binary")]
 pub fn read_binary(
-    env: rustler::Env,
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     memory_resource: ResourceArc<MemoryResource>,
     index: usize,
     len: usize,
-) -> NifResult<Binary> {
-    let store_or_caller: &StoreOrCaller =
-        &*(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource: {e}"
-            )))
-        })?);
-    let memory: &Memory = &*(memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
-    })?);
-    let mut buffer = vec![0u8; len];
+    from: Term,
+) -> Result<Atom, rustler::Error> {
+    let memory = clone_memory(&memory_resource)?;
+    let reply = AsyncReply::new(from);
 
-    memory
-        .read(store_or_caller, index, &mut buffer)
-        .map_err(|err| Error::Term(Box::new(err.to_string())))?;
-
-    let mut binary = NewBinary::new(env, len);
-    binary.as_mut_slice().write_all(&buffer).unwrap();
-
-    Ok(binary.into())
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |store| async move {
+                let mut buffer = vec![0u8; len];
+                match memory.read(&store, index, &mut buffer) {
+                    Ok(()) => reply.send_binary(buffer),
+                    Err(error) => reply.send_error(error.to_string()),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = CallerCommand::MemoryRead {
+                memory,
+                index,
+                len,
+                reply,
+            };
+            if let Err(CallerCommand::MemoryRead { reply, .. }) = session.submit(command) {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
+    }
+    Ok(atoms::ok())
 }
 
-#[rustler::nif(name = "memory_write_binary", schedule = "DirtyCpu")]
+#[rustler::nif(name = "memory_write_binary")]
 pub fn write_binary(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     memory_resource: ResourceArc<MemoryResource>,
     index: usize,
     binary: Binary,
-) -> NifResult<Atom> {
-    let store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource: {e}"
-            )))
-        })?);
-    let memory: &Memory = &*(memory_resource.inner.lock().map_err(|e| {
-        rustler::Error::Term(Box::new(format!("Could not unlock memory resource: {e}")))
-    })?);
-    memory
-        .write(store_or_caller, index, binary.as_slice())
-        .map_err(|err| Error::Term(Box::new(err.to_string())))?;
+    from: Term,
+) -> Result<Atom, rustler::Error> {
+    let memory = clone_memory(&memory_resource)?;
+    let bytes = binary.as_slice().to_vec();
+    let reply = AsyncReply::new(from);
 
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |mut store| async move {
+                match memory.write(&mut store, index, &bytes) {
+                    Ok(()) => reply.send(atoms::ok()),
+                    Err(error) => reply.send_error(error.to_string()),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            let command = CallerCommand::MemoryWrite {
+                memory,
+                index,
+                bytes,
+                reply,
+            };
+            if let Err(CallerCommand::MemoryWrite { reply, .. }) = session.submit(command) {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
+    }
     Ok(atoms::ok())
 }

--- a/native/wasmex/src/module.rs
+++ b/native/wasmex/src/module.rs
@@ -1,7 +1,7 @@
 use crate::{
     atoms,
     engine::{unwrap_engine, EngineResource},
-    store::{StoreOrCaller, StoreOrCallerResource},
+    store::StoreOrCallerResource,
 };
 use rustler::{
     types::tuple::make_tuple, Binary, Encoder, Env, NifResult, OwnedBinary, ResourceArc, Term,
@@ -23,15 +23,14 @@ pub fn compile(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     binary: Binary,
 ) -> Result<ResourceArc<ModuleResource>, rustler::Error> {
-    let store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!(
-                "Could not unlock store_or_caller resource as the mutex was poisoned: {e}"
-            )))
-        })?);
     let bytes = binary.as_slice();
     let bytes = wat::parse_bytes(bytes)
         .map_err(|e| rustler::Error::Term(Box::new(format!("Error while parsing bytes: {e}."))))?;
+    let store_or_caller = store_or_caller_resource.inner.lock().map_err(|error| {
+        rustler::Error::Term(Box::new(format!(
+            "Could not unlock store_or_caller resource: {error}"
+        )))
+    })?;
     match Module::new(store_or_caller.engine(), bytes) {
         Ok(module) => {
             let resource = ResourceArc::new(ModuleResource {

--- a/native/wasmex/src/store.rs
+++ b/native/wasmex/src/store.rs
@@ -3,10 +3,13 @@ use crate::{
     caller::{CallbackSession, CallerCommand},
     engine::{unwrap_engine_and_ticker, EngineResource},
     pipe::{Pipe, PipeResource},
-    store_executor::StoreExecutor,
+    store_executor::{InterruptState, StoreExecutor},
 };
 use rustler::{Atom, Error, NifStruct, ResourceArc, Term};
-use std::{collections::HashMap, sync::Mutex};
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicBool, Arc, Mutex},
+};
 use wasmtime::{Engine, Store, StoreLimits, StoreLimitsBuilder};
 use wasmtime_wasi::{
     p1::WasiP1Ctx, DirPerms, FilePerms, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView,
@@ -102,6 +105,7 @@ impl ExStoreLimits {
 pub struct StoreData {
     pub(crate) wasi: Option<WasiP1Ctx>,
     pub(crate) limits: StoreLimits,
+    pub(crate) interrupt_requested: Arc<AtomicBool>,
 }
 
 pub struct ComponentStoreData {
@@ -109,6 +113,19 @@ pub struct ComponentStoreData {
     pub(crate) http: Option<WasiHttpCtx>,
     pub(crate) limits: StoreLimits,
     pub(crate) table: ResourceTable,
+    pub(crate) interrupt_requested: Arc<AtomicBool>,
+}
+
+impl InterruptState for StoreData {
+    fn interrupt_requested(&self) -> &AtomicBool {
+        &self.interrupt_requested
+    }
+}
+
+impl InterruptState for ComponentStoreData {
+    fn interrupt_requested(&self) -> &AtomicBool {
+        &self.interrupt_requested
+    }
 }
 
 impl WasiHttpView for ComponentStoreData {
@@ -202,7 +219,14 @@ pub fn new(
     } else {
         StoreLimits::default()
     };
-    let mut store = Store::new(&engine, StoreData { wasi: None, limits });
+    let mut store = Store::new(
+        &engine,
+        StoreData {
+            wasi: None,
+            limits,
+            interrupt_requested: Arc::new(AtomicBool::new(false)),
+        },
+    );
     store.limiter(|state| &mut state.limits);
     let resource = ResourceArc::new(StoreOrCallerResource {
         inner: Mutex::new(StoreOrCaller::Store(StoreExecutor::new_async(
@@ -230,6 +254,7 @@ pub fn component_store_new(
             ctx: None,
             limits,
             table: wasmtime_wasi::ResourceTable::new(),
+            interrupt_requested: Arc::new(AtomicBool::new(false)),
         },
     );
     store.limiter(|state| &mut state.limits);
@@ -291,6 +316,7 @@ pub fn component_store_new_wasi(
             limits,
             http: http_option,
             table: wasmtime_wasi::ResourceTable::new(),
+            interrupt_requested: Arc::new(AtomicBool::new(false)),
         },
     );
     store.limiter(|state| &mut state.limits);
@@ -339,6 +365,7 @@ pub fn new_wasi(
         StoreData {
             wasi: Some(wasi_ctx),
             limits,
+            interrupt_requested: Arc::new(AtomicBool::new(false)),
         },
     );
     store.limiter(|state| &mut state.limits);
@@ -356,10 +383,10 @@ pub fn set_fuel(
     fuel: u64,
     from: Term,
 ) -> Result<Atom, rustler::Error> {
-    let reply = AsyncReply::new(from);
+    let reply = AsyncReply::new(from)?;
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |mut store| async move {
                 match store.set_fuel(fuel) {
                     Ok(()) => reply.send(()),
@@ -371,10 +398,8 @@ pub fn set_fuel(
             }
         }
         StoreTarget::Caller(session) => {
-            if let Err(CallerCommand::SetFuel { reply, .. }) =
-                session.submit(CallerCommand::SetFuel { fuel, reply })
-            {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(CallerCommand::SetFuel { fuel, reply }) {
+                error.reject();
             }
         }
     }
@@ -386,10 +411,10 @@ pub fn get_fuel(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     from: Term,
 ) -> Result<Atom, rustler::Error> {
-    let reply = AsyncReply::new(from);
+    let reply = AsyncReply::new(from)?;
     match store_or_caller_resource.target()? {
         StoreTarget::Executor(executor) => {
-            let submit_reply = AsyncReply::new(from);
+            let submit_reply = AsyncReply::new(from)?;
             if let Err(error) = executor.submit(move |store| async move {
                 match store.get_fuel() {
                     Ok(fuel) => reply.send(fuel),
@@ -401,10 +426,8 @@ pub fn get_fuel(
             }
         }
         StoreTarget::Caller(session) => {
-            if let Err(CallerCommand::GetFuel { reply }) =
-                session.submit(CallerCommand::GetFuel { reply })
-            {
-                reply.send_error("Caller is no longer valid");
+            if let Err(error) = session.submit(CallerCommand::GetFuel { reply }) {
+                error.reject();
             }
         }
     }

--- a/native/wasmex/src/store.rs
+++ b/native/wasmex/src/store.rs
@@ -1,14 +1,13 @@
 use crate::{
-    caller::{get_caller, get_caller_mut},
-    engine::{unwrap_engine, EngineResource},
+    async_reply::{submit_error, AsyncReply},
+    caller::{CallbackSession, CallerCommand},
+    engine::{unwrap_engine_and_ticker, EngineResource},
     pipe::{Pipe, PipeResource},
+    store_executor::StoreExecutor,
 };
-use rustler::{Error, NifStruct, ResourceArc};
+use rustler::{Atom, Error, NifStruct, ResourceArc, Term};
 use std::{collections::HashMap, sync::Mutex};
-use wasmtime::{
-    AsContext, AsContextMut, Engine, Store, StoreContext, StoreContextMut, StoreLimits,
-    StoreLimitsBuilder,
-};
+use wasmtime::{Engine, Store, StoreLimits, StoreLimitsBuilder};
 use wasmtime_wasi::{
     p1::WasiP1Ctx, DirPerms, FilePerms, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView,
 };
@@ -133,8 +132,8 @@ impl WasiView for ComponentStoreData {
 }
 
 pub enum StoreOrCaller {
-    Store(Store<StoreData>),
-    Caller(i32),
+    Store(StoreExecutor<StoreData>),
+    Caller(CallbackSession),
 }
 
 pub struct StoreOrCallerResource {
@@ -142,7 +141,7 @@ pub struct StoreOrCallerResource {
 }
 
 pub struct ComponentStoreResource {
-    pub inner: Mutex<Store<ComponentStoreData>>,
+    pub inner: Mutex<StoreExecutor<ComponentStoreData>>,
 }
 
 #[rustler::resource_impl()]
@@ -155,36 +154,41 @@ impl StoreOrCaller {
     pub fn engine(&self) -> &Engine {
         match self {
             StoreOrCaller::Store(store) => store.engine(),
-            StoreOrCaller::Caller(token) => get_caller(token).unwrap().engine(),
-        }
-    }
-
-    pub fn data(&self) -> &StoreData {
-        match self {
-            StoreOrCaller::Store(store) => store.data(),
-            StoreOrCaller::Caller(token) => get_caller(token).unwrap().data(),
+            StoreOrCaller::Caller(session) => session.engine(),
         }
     }
 }
 
-impl AsContext for StoreOrCaller {
-    type Data = StoreData;
-
-    fn as_context(&self) -> StoreContext<'_, Self::Data> {
-        match self {
-            StoreOrCaller::Store(store) => store.as_context(),
-            StoreOrCaller::Caller(token) => get_caller(token).unwrap().as_context(),
+impl StoreOrCallerResource {
+    pub fn target(&self) -> Result<StoreTarget, rustler::Error> {
+        let inner = self.inner.lock().map_err(|error| {
+            rustler::Error::Term(Box::new(format!(
+                "Could not unlock store resource: {error}"
+            )))
+        })?;
+        match &*inner {
+            StoreOrCaller::Store(executor) => Ok(StoreTarget::Executor(executor.clone())),
+            StoreOrCaller::Caller(session) => Ok(StoreTarget::Caller(session.clone())),
         }
     }
 }
 
-impl AsContextMut for StoreOrCaller {
-    fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::Data> {
-        match self {
-            StoreOrCaller::Store(store) => store.as_context_mut(),
-            StoreOrCaller::Caller(token) => get_caller_mut(token).unwrap().as_context_mut(),
-        }
+impl ComponentStoreResource {
+    pub fn executor(&self) -> Result<StoreExecutor<ComponentStoreData>, rustler::Error> {
+        self.inner
+            .lock()
+            .map(|executor| executor.clone())
+            .map_err(|error| {
+                rustler::Error::Term(Box::new(format!(
+                    "Could not unlock component store resource: {error}"
+                )))
+            })
     }
+}
+
+pub enum StoreTarget {
+    Executor(StoreExecutor<StoreData>),
+    Caller(CallbackSession),
 }
 
 #[rustler::nif(name = "store_new")]
@@ -192,7 +196,7 @@ pub fn new(
     limits: Option<ExStoreLimits>,
     engine_resource: ResourceArc<EngineResource>,
 ) -> Result<ResourceArc<StoreOrCallerResource>, rustler::Error> {
-    let engine = unwrap_engine(engine_resource)?;
+    let (engine, ticker) = unwrap_engine_and_ticker(engine_resource)?;
     let limits = if let Some(limits) = limits {
         limits.to_wasmtime()
     } else {
@@ -201,7 +205,9 @@ pub fn new(
     let mut store = Store::new(&engine, StoreData { wasi: None, limits });
     store.limiter(|state| &mut state.limits);
     let resource = ResourceArc::new(StoreOrCallerResource {
-        inner: Mutex::new(StoreOrCaller::Store(store)),
+        inner: Mutex::new(StoreOrCaller::Store(StoreExecutor::new_async(
+            store, ticker,
+        ))),
     });
     Ok(resource)
 }
@@ -211,7 +217,7 @@ pub fn component_store_new(
     limits: Option<ExStoreLimits>,
     engine_resource: ResourceArc<EngineResource>,
 ) -> Result<ResourceArc<ComponentStoreResource>, rustler::Error> {
-    let engine = unwrap_engine(engine_resource)?;
+    let (engine, ticker) = unwrap_engine_and_ticker(engine_resource)?;
     let limits = if let Some(limits) = limits {
         limits.to_wasmtime()
     } else {
@@ -228,7 +234,7 @@ pub fn component_store_new(
     );
     store.limiter(|state| &mut state.limits);
     let resource: ResourceArc<ComponentStoreResource> = ResourceArc::new(ComponentStoreResource {
-        inner: Mutex::new(store),
+        inner: Mutex::new(StoreExecutor::new_async(store, ticker)),
     });
     Ok(resource)
 }
@@ -265,7 +271,7 @@ pub fn component_store_new_wasi(
             .allow_ip_name_lookup(true);
     }
 
-    let engine = unwrap_engine(engine_resource)?;
+    let (engine, ticker) = unwrap_engine_and_ticker(engine_resource)?;
     let limits = if let Some(limits) = limits {
         limits.to_wasmtime()
     } else {
@@ -289,7 +295,7 @@ pub fn component_store_new_wasi(
     );
     store.limiter(|state| &mut state.limits);
     let resource: ResourceArc<ComponentStoreResource> = ResourceArc::new(ComponentStoreResource {
-        inner: Mutex::new(store),
+        inner: Mutex::new(StoreExecutor::new_async(store, ticker)),
     });
     Ok(resource)
 }
@@ -322,7 +328,7 @@ pub fn new_wasi(
     wasi_preopen_directories(options.preopen, &mut builder)?;
     let wasi_ctx = builder.build_p1();
 
-    let engine = unwrap_engine(engine_resource)?;
+    let (engine, ticker) = unwrap_engine_and_ticker(engine_resource)?;
     let limits = if let Some(limits) = limits {
         limits.to_wasmtime()
     } else {
@@ -337,7 +343,9 @@ pub fn new_wasi(
     );
     store.limiter(|state| &mut state.limits);
     let resource = ResourceArc::new(StoreOrCallerResource {
-        inner: Mutex::new(StoreOrCaller::Store(store)),
+        inner: Mutex::new(StoreOrCaller::Store(StoreExecutor::new_async(
+            store, ticker,
+        ))),
     });
     Ok(resource)
 }
@@ -346,43 +354,61 @@ pub fn new_wasi(
 pub fn set_fuel(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
     fuel: u64,
-) -> Result<(), rustler::Error> {
-    let store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.try_lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
-        })?);
-    match store_or_caller {
-        StoreOrCaller::Store(store) => store.set_fuel(fuel),
-        StoreOrCaller::Caller(token) => get_caller_mut(token)
-            .ok_or_else(|| {
-                rustler::Error::Term(Box::new(
-                    "Caller is not valid. Only use a caller within its own function scope.",
-                ))
-            })
-            .map(|c| c.set_fuel(fuel))?,
+    from: Term,
+) -> Result<Atom, rustler::Error> {
+    let reply = AsyncReply::new(from);
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |mut store| async move {
+                match store.set_fuel(fuel) {
+                    Ok(()) => reply.send(()),
+                    Err(error) => reply.send_error(format!("Could not set fuel: {error}")),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            if let Err(CallerCommand::SetFuel { reply, .. }) =
+                session.submit(CallerCommand::SetFuel { fuel, reply })
+            {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
     }
-    .map_err(|e| rustler::Error::Term(Box::new(format!("Could not set fuel: {e}"))))
+    Ok(crate::atoms::ok())
 }
 
 #[rustler::nif(name = "store_or_caller_get_fuel")]
 pub fn get_fuel(
     store_or_caller_resource: ResourceArc<StoreOrCallerResource>,
-) -> Result<u64, rustler::Error> {
-    let store_or_caller: &mut StoreOrCaller =
-        &mut *(store_or_caller_resource.inner.try_lock().map_err(|e| {
-            rustler::Error::Term(Box::new(format!("Could not unlock store resource: {e}")))
-        })?);
-    match store_or_caller {
-        StoreOrCaller::Store(store) => store.get_fuel(),
-        StoreOrCaller::Caller(token) => get_caller_mut(token)
-            .ok_or_else(|| {
-                rustler::Error::Term(Box::new(
-                    "Caller is not valid. Only use a caller within its own function scope.",
-                ))
-            })
-            .map(|c| c.get_fuel())?,
+    from: Term,
+) -> Result<Atom, rustler::Error> {
+    let reply = AsyncReply::new(from);
+    match store_or_caller_resource.target()? {
+        StoreTarget::Executor(executor) => {
+            let submit_reply = AsyncReply::new(from);
+            if let Err(error) = executor.submit(move |store| async move {
+                match store.get_fuel() {
+                    Ok(fuel) => reply.send(fuel),
+                    Err(error) => reply.send_error(format!("Could not get fuel: {error}")),
+                }
+                store
+            }) {
+                submit_error(submit_reply, error);
+            }
+        }
+        StoreTarget::Caller(session) => {
+            if let Err(CallerCommand::GetFuel { reply }) =
+                session.submit(CallerCommand::GetFuel { reply })
+            {
+                reply.send_error("Caller is no longer valid");
+            }
+        }
     }
-    .map_err(|e| rustler::Error::Term(Box::new(format!("Could not get fuel: {e}"))))
+    Ok(crate::atoms::ok())
 }
 
 fn add_pipe<F>(

--- a/native/wasmex/src/store_executor.rs
+++ b/native/wasmex/src/store_executor.rs
@@ -1,0 +1,144 @@
+use std::{future::Future, pin::Pin};
+
+use tokio::sync::mpsc;
+use wasmtime::{Engine, Store};
+
+const DEFAULT_QUEUE_CAPACITY: usize = 1024;
+
+type StoreFuture<T> = Pin<Box<dyn Future<Output = Store<T>> + Send + 'static>>;
+type StoreCommand<T> = Box<dyn FnOnce(Store<T>) -> StoreFuture<T> + Send + 'static>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmitError {
+    Busy,
+    Closed,
+}
+
+/// Serializes access to a Wasmtime Store without blocking an executor thread.
+///
+/// A Store is owned by one long-lived Tokio task. NIF calls enqueue owned
+/// commands and return to the BEAM; the executor runs one command at a time,
+/// preserving Wasmtime's single-owner requirement.
+pub struct StoreExecutor<T: 'static> {
+    sender: mpsc::Sender<StoreCommand<T>>,
+    engine: Engine,
+}
+
+impl<T: 'static> Clone for StoreExecutor<T> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            engine: self.engine.clone(),
+        }
+    }
+}
+
+impl<T: Send + 'static> StoreExecutor<T> {
+    pub(crate) fn new_async(mut store: Store<T>, epoch_ticker: crate::engine::EpochTicker) -> Self {
+        store.set_epoch_deadline(1);
+        store.epoch_deadline_async_yield_and_update(1);
+        Self::with_capacity(store, DEFAULT_QUEUE_CAPACITY, Some(epoch_ticker))
+    }
+
+    fn with_capacity(
+        store: Store<T>,
+        capacity: usize,
+        epoch_ticker: Option<crate::engine::EpochTicker>,
+    ) -> Self {
+        let engine = store.engine().clone();
+        let (sender, mut receiver) = mpsc::channel::<StoreCommand<T>>(capacity);
+
+        crate::engine::TOKIO_RUNTIME.spawn(async move {
+            let _epoch_ticker = epoch_ticker;
+            let mut store = store;
+            while let Some(command) = receiver.recv().await {
+                store = command(store).await;
+            }
+        });
+
+        Self { sender, engine }
+    }
+
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    pub fn submit<F, Fut>(&self, command: F) -> Result<(), SubmitError>
+    where
+        F: FnOnce(Store<T>) -> Fut + Send + 'static,
+        Fut: Future<Output = Store<T>> + Send + 'static,
+    {
+        self.sender
+            .try_send(Box::new(move |store| Box::pin(command(store))))
+            .map_err(|error| match error {
+                mpsc::error::TrySendError::Full(_) => SubmitError::Busy,
+                mpsc::error::TrySendError::Closed(_) => SubmitError::Closed,
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use wasmtime::{Engine, Store};
+
+    use super::{StoreExecutor, SubmitError};
+
+    #[test]
+    fn executes_commands_in_submission_order() {
+        let executor =
+            StoreExecutor::with_capacity(Store::new(&Engine::default(), 0usize), 2, None);
+        let observed = Arc::new(AtomicUsize::new(0));
+
+        for expected in 0..2 {
+            let observed = observed.clone();
+            executor
+                .submit(move |mut store| async move {
+                    assert_eq!(*store.data(), expected);
+                    *store.data_mut() += 1;
+                    observed.fetch_add(1, Ordering::SeqCst);
+                    store
+                })
+                .unwrap();
+        }
+
+        while observed.load(Ordering::SeqCst) != 2 {
+            std::thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn reports_backpressure() {
+        let executor = StoreExecutor::with_capacity(Store::new(&Engine::default(), ()), 1, None);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let (finish_queued_tx, finish_queued_rx) = tokio::sync::oneshot::channel();
+
+        executor
+            .submit(move |store| async move {
+                started_tx.send(()).unwrap();
+                let _ = finish_rx.await;
+                store
+            })
+            .unwrap();
+        started_rx.recv().unwrap();
+
+        executor
+            .submit(move |store| async move {
+                let _ = finish_queued_rx.await;
+                store
+            })
+            .unwrap();
+
+        assert_eq!(
+            executor.submit(|store| async move { store }),
+            Err(SubmitError::Busy)
+        );
+        finish_tx.send(()).unwrap();
+        finish_queued_tx.send(()).unwrap();
+    }
+}

--- a/native/wasmex/src/store_executor.rs
+++ b/native/wasmex/src/store_executor.rs
@@ -1,12 +1,23 @@
-use std::{future::Future, pin::Pin};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use tokio::sync::mpsc;
-use wasmtime::{Engine, Store};
+use wasmtime::{Engine, Store, UpdateDeadline};
 
 const DEFAULT_QUEUE_CAPACITY: usize = 1024;
 
 type StoreFuture<T> = Pin<Box<dyn Future<Output = Store<T>> + Send + 'static>>;
 type StoreCommand<T> = Box<dyn FnOnce(Store<T>) -> StoreFuture<T> + Send + 'static>;
+
+pub trait InterruptState {
+    fn interrupt_requested(&self) -> &AtomicBool;
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubmitError {
@@ -33,13 +44,21 @@ impl<T: 'static> Clone for StoreExecutor<T> {
     }
 }
 
-impl<T: Send + 'static> StoreExecutor<T> {
+impl<T: InterruptState + Send + 'static> StoreExecutor<T> {
     pub(crate) fn new_async(mut store: Store<T>, epoch_ticker: crate::engine::EpochTicker) -> Self {
         store.set_epoch_deadline(1);
-        store.epoch_deadline_async_yield_and_update(1);
+        store.epoch_deadline_callback(|store| {
+            if store.data().interrupt_requested().load(Ordering::Acquire) {
+                Ok(UpdateDeadline::Interrupt)
+            } else {
+                Ok(UpdateDeadline::Yield(1))
+            }
+        });
         Self::with_capacity(store, DEFAULT_QUEUE_CAPACITY, Some(epoch_ticker))
     }
+}
 
+impl<T: Send + 'static> StoreExecutor<T> {
     fn with_capacity(
         store: Store<T>,
         capacity: usize,
@@ -74,6 +93,35 @@ impl<T: Send + 'static> StoreExecutor<T> {
                 mpsc::error::TrySendError::Full(_) => SubmitError::Busy,
                 mpsc::error::TrySendError::Closed(_) => SubmitError::Closed,
             })
+    }
+}
+
+pub async fn with_deadline<F>(
+    interrupt_requested: Arc<AtomicBool>,
+    deadline: Option<tokio::time::Instant>,
+    future: F,
+) -> Option<F::Output>
+where
+    F: Future,
+{
+    let Some(deadline) = deadline else {
+        return Some(future.await);
+    };
+    interrupt_requested.store(false, Ordering::Release);
+    if deadline <= tokio::time::Instant::now() {
+        return None;
+    }
+
+    tokio::pin!(future);
+    tokio::select! {
+        biased;
+        _ = tokio::time::sleep_until(deadline) => {
+            interrupt_requested.store(true, Ordering::Release);
+            let _ = future.await;
+            interrupt_requested.store(false, Ordering::Release);
+            None
+        }
+        output = &mut future => Some(output),
     }
 }
 

--- a/test/components/component_server_test.exs
+++ b/test/components/component_server_test.exs
@@ -2,6 +2,11 @@ defmodule Wasmex.Components.GenServerTest do
   use ExUnit.Case, async: true
   alias Wasmex.Wasi.WasiP2Options
 
+  test "the low-level component call keeps its optional timeout" do
+    assert function_exported?(Wasmex.Components.Instance, :call_function, 4)
+    assert function_exported?(Wasmex.Components.Instance, :call_function, 5)
+  end
+
   test "interacting with a component GenServer" do
     component_bytes = File.read!(TestHelper.component_type_conversions_file_path())
 
@@ -105,5 +110,66 @@ defmodule Wasmex.Components.GenServerTest do
     # With conversion disabled, need to use kebab-field format
     assert {:ok, %{"kebab-field" => "test"}} =
              HelloWorldNoConversion.echo_kebab(component_pid, %{"kebab-field" => "test"})
+  end
+
+  test "a callback completing after timeout does not terminate the component server" do
+    component_bytes = File.read!("test/component_fixtures/hello_world/hello_world.wasm")
+
+    imports = %{
+      "greeter" =>
+        {:fn,
+         fn ->
+           Process.sleep(100)
+           "Elixir"
+         end}
+    }
+
+    component_pid =
+      start_supervised!(
+        {Wasmex.Components,
+         bytes: component_bytes, wasi: %WasiP2Options{allow_http: true}, imports: imports}
+      )
+
+    assert catch_exit(Wasmex.Components.call_function(component_pid, "greet", ["World"], 10))
+    Process.sleep(150)
+
+    assert Process.alive?(component_pid)
+
+    assert {:ok, "Hello, World from Elixir!"} =
+             Wasmex.Components.call_function(component_pid, "greet", ["World"])
+  end
+
+  test "an invalid callback result does not terminate the component server" do
+    component_bytes = File.read!("test/component_fixtures/hello_world/hello_world.wasm")
+
+    component_pid =
+      start_supervised!(
+        {Wasmex.Components,
+         bytes: component_bytes,
+         wasi: %WasiP2Options{allow_http: true},
+         imports: %{"greeter" => {:fn, fn -> 42 end}}}
+      )
+
+    assert {:error, _reason} =
+             Wasmex.Components.call_function(component_pid, "greet", ["World"])
+
+    assert Process.alive?(component_pid)
+  end
+
+  test "a callback exception does not terminate the component server" do
+    component_bytes = File.read!("test/component_fixtures/hello_world/hello_world.wasm")
+
+    component_pid =
+      start_supervised!(
+        {Wasmex.Components,
+         bytes: component_bytes,
+         wasi: %WasiP2Options{allow_http: true},
+         imports: %{"greeter" => {:fn, fn -> raise "callback failed" end}}}
+      )
+
+    assert {:error, _reason} =
+             Wasmex.Components.call_function(component_pid, "greet", ["World"])
+
+    assert Process.alive?(component_pid)
   end
 end

--- a/test/wasmex/module_test.exs
+++ b/test/wasmex/module_test.exs
@@ -79,7 +79,12 @@ defmodule Wasmex.ModuleTest do
         "void" => {:fn, [], []}
       }
 
-      assert expected == Wasmex.Module.exports(module)
+      exports =
+        module
+        |> Wasmex.Module.exports()
+        |> Map.drop(["__data_end", "__heap_base"])
+
+      assert expected == exports
     end
 
     test "lists table data" do

--- a/test/wasmex/store_test.exs
+++ b/test/wasmex/store_test.exs
@@ -3,6 +3,7 @@ defmodule Wasmex.StoreTest do
   import TestHelper, only: [t: 1]
 
   doctest Wasmex.Store
+  doctest Wasmex.StoreLimits
 
   describe t(&Store.new/0) do
     test "creates a new Store" do

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -319,6 +319,8 @@ defmodule WasmexTest do
       {:ok, engine} = Wasmex.Engine.new(%Wasmex.EngineConfig{consume_fuel: true})
       {:ok, store} = Wasmex.Store.new(nil, engine)
       bytes = File.read!(TestHelper.wasm_test_file_path())
+      # Instantiation may execute a compiler-generated start function.
+      Wasmex.StoreOrCaller.set_fuel(store, 1_000_000_000)
       pid = start_supervised!({Wasmex, %{store: store, bytes: bytes}})
       Wasmex.StoreOrCaller.set_fuel(store, 2)
 
@@ -467,6 +469,74 @@ defmodule WasmexTest do
       pid = start_supervised!({Wasmex, %{store: store, module: module, imports: imports}})
       assert Wasmex.call_function(pid, :call_import, [1, 2]) == {:ok, [3]}
     end
+
+    test "using globals and export lookup through the scoped Caller" do
+      wat = """
+      (module
+        (import "env" "inspect_instance" (func $inspect_instance (result i32)))
+        (global $count (export "count") (mut i32) (i32.const 1))
+
+        (func $call_import (export "call_import") (result i32)
+          call $inspect_instance
+        )
+      )
+      """
+
+      imports = %{
+        env: %{
+          inspect_instance:
+            {:fn, [], [:i32],
+             fn %{instance: instance, caller: caller} ->
+               assert Wasmex.Instance.function_export_exists(caller, instance, "call_import")
+               assert {:ok, 1} = Wasmex.Instance.get_global_value(caller, instance, "count")
+               assert :ok = Wasmex.Instance.set_global_value(caller, instance, "count", 42)
+               42
+             end}
+        }
+      }
+
+      {:ok, pid} = Wasmex.start_link(%{bytes: wat, imports: imports})
+
+      assert {:ok, [42]} = Wasmex.call_function(pid, :call_import, [])
+      assert {:ok, store} = Wasmex.store(pid)
+      assert {:ok, instance} = Wasmex.instance(pid)
+      assert {:ok, 42} = Wasmex.Instance.get_global_value(store, instance, "count")
+    end
+
+    test "instantiating another module through the scoped Caller" do
+      wat = """
+      (module
+        (import "env" "create_instance" (func $create_instance (result i32)))
+        (func (export "run") (result i32)
+          call $create_instance
+        )
+      )
+      """
+
+      child_wat = """
+      (module
+        (func (export "answer") (result i32)
+          i32.const 42
+        )
+      )
+      """
+
+      imports = %{
+        env: %{
+          create_instance:
+            {:fn, [], [:i32],
+             fn %{caller: caller} ->
+               assert {:ok, module} = Wasmex.Module.compile(caller, child_wat)
+               assert {:ok, instance} = Wasmex.Instance.new(caller, module, %{})
+               assert Wasmex.Instance.function_export_exists(caller, instance, "answer")
+               1
+             end}
+        }
+      }
+
+      {:ok, pid} = Wasmex.start_link(%{bytes: wat, imports: imports})
+      assert {:ok, [1]} = Wasmex.call_function(pid, :run, [])
+    end
   end
 
   describe "unsafe_deserialize && serialize modules" do
@@ -512,7 +582,7 @@ defmodule WasmexTest do
     end
 
     test "high concurrency - 1000 concurrent WebAssembly function calls" do
-      # This test demonstrates Tokio's efficiency with green threads vs OS threads
+      # This test exercises the Store executor without creating one OS thread per call.
       wat = """
       (module
         (func $add (export "add") (param i32 i32) (result i32)
@@ -617,6 +687,26 @@ defmodule WasmexTest do
 
       # Wait for WASM tasks to complete
       Task.await_many(wasm_tasks, 10_000)
+    end
+
+    test "a timed-out infinite call is cancelled and releases its Store" do
+      wat = """
+      (module
+        (func $run_forever (export "run_forever")
+          (loop $forever
+            br $forever
+          )
+        )
+        (func $identity (export "identity") (param i32) (result i32)
+          local.get 0
+        )
+      )
+      """
+
+      {:ok, pid} = Wasmex.start_link(%{bytes: wat})
+
+      assert catch_exit(Wasmex.call_function(pid, :run_forever, [], 50))
+      assert {:ok, [42]} = Wasmex.call_function(pid, :identity, [42], 1_000)
     end
 
     test "error handling in highly concurrent scenario" do

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -709,6 +709,61 @@ defmodule WasmexTest do
       assert {:ok, [42]} = Wasmex.call_function(pid, :identity, [42], 1_000)
     end
 
+    test "a callback completing after timeout does not terminate the server" do
+      wat = """
+      (module
+        (import "env" "slow" (func $slow (result i32)))
+        (func (export "run") (result i32)
+          call $slow
+        )
+        (func (export "identity") (param i32) (result i32)
+          local.get 0
+        )
+      )
+      """
+
+      imports = %{
+        env: %{
+          slow:
+            {:fn, [], [:i32],
+             fn _context ->
+               Process.sleep(100)
+               1
+             end}
+        }
+      }
+
+      pid = start_supervised!({Wasmex, %{bytes: wat, imports: imports}})
+
+      assert catch_exit(Wasmex.call_function(pid, :run, [], 10))
+      Process.sleep(150)
+
+      assert Process.alive?(pid)
+      assert {:ok, [42]} = Wasmex.call_function(pid, :identity, [42])
+    end
+
+    test "an invalid callback result does not terminate the server" do
+      wat = """
+      (module
+        (import "env" "invalid" (func $invalid (result i32)))
+        (func (export "run") (result i32)
+          call $invalid
+        )
+      )
+      """
+
+      imports = %{
+        env: %{
+          invalid: {:fn, [], [:i32], fn _context -> "not an integer" end}
+        }
+      }
+
+      pid = start_supervised!({Wasmex, %{bytes: wat, imports: imports}})
+
+      assert {:error, _reason} = Wasmex.call_function(pid, :run, [])
+      assert Process.alive?(pid)
+    end
+
     test "error handling in highly concurrent scenario" do
       # Test that errors in some tasks don't affect others
       wat = """


### PR DESCRIPTION
## Why

Wasmtime Stores require serialized ownership, while WebAssembly execution and host callbacks should not block Tokio worker threads or the BEAM. The new executor keeps one owner per Store, preserves operation ordering, provides bounded backpressure, and allows Wasmtime's async execution to yield cooperatively.

The callback and reply changes also prevent late replies after caller timeouts, invalid callback results, and callback exceptions from terminating the Wasmex server or leaving Wasmtime calls blocked.

## Timeout behavior

Core WebAssembly calls are interrupted after their deadline and release their Store for later work.
Wasmtime does not currently support safely cancelling an in-progress _component_ call while preserving its instance, so component calls that exceed the caller timeout finish in the background and their late result is discarded.

## Changes

- move core and component Store operations onto bounded, single-owner Tokio executors
- use Wasmtime's asynchronous APIs for instantiation, function execution, WASI, and WASI HTTP work
- add cooperative epoch yielding and safe interruption for timed-out core WebAssembly calls
- keep timed-out component calls running to completion while discarding late replies, preserving the component instance
- replace callback-scoped access with bounded asynchronous Caller sessions and harden late, invalid, and failed callback replies
- restore the low-level component `call_function/4` API and refresh the README, module documentation, examples, and changelog


