### PR TITLE
Support named core Wasmex servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Types of changes
 
 ## [Unreleased]
 
+### Added
+
+- Added support for registering core Wasmex GenServers with the `:name` option.
+
 ### Fixed
 
 - Corrected public typespecs to accept registered GenServer names and to reflect the full range of WebAssembly component parameter and return values. Thanks @Sorixelle (#971)

--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -39,6 +39,13 @@ defmodule Wasmex do
       iex> bytes = File.read!(TestHelper.wasm_test_file_path())
       iex> {:ok, _pid} = Wasmex.start_link(%{bytes: bytes})
 
+  A process name can be registered with the `:name` option:
+
+      iex> bytes = File.read!(TestHelper.wasm_test_file_path())
+      iex> {:ok, _pid} = Wasmex.start_link(%{bytes: bytes, name: MyWasm})
+      iex> Wasmex.call_function(MyWasm, "sum", [50, -8])
+      {:ok, [42]}
+
   Alternatively, a precompiled `Wasmex.Module` can be passed with its `Wasmex.Store`:
 
       iex> {:ok, store} = Wasmex.Store.new()
@@ -254,13 +261,16 @@ defmodule Wasmex do
       |> Enum.uniq_by(&elem(&1, 0))
       |> Enum.map(&build_compiled_links(&1, store))
 
-    GenServer.start_link(__MODULE__, %{
+    state = %{
       store: store,
       module: module,
       instance: instance,
       links: compiled_links,
       imports: imports
-    })
+    }
+
+    gen_server_opts = opts |> Map.take([:name]) |> Map.to_list()
+    GenServer.start_link(__MODULE__, state, gen_server_opts)
   end
 
   defp flatten_links(links) do

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -4,6 +4,16 @@ defmodule WasmexTest do
 
   doctest Wasmex
 
+  test "register by name" do
+    %{module: module, store: store} = TestHelper.wasm_module()
+
+    _pid =
+      start_supervised!({Wasmex, %{store: store, module: module, name: WasmexTest.Registered}})
+
+    assert Wasmex.function_exists(WasmexTest.Registered, :arity_0)
+    assert {:ok, [42]} = Wasmex.call_function(WasmexTest.Registered, :arity_0, [])
+  end
+
   defp start_wasmex_gen_server(_context) do
     %{module: module, store: store} = TestHelper.wasm_module()
     pid = start_supervised!({Wasmex, %{store: store, module: module}})


### PR DESCRIPTION
`Wasmex.Components.start_link/1` supports standard GenServer naming, but core `Wasmex.start_link/1` currently consumes its Wasmex options and starts the GenServer without forwarding `:name`. Callers therefore cannot register a core Wasmex server during startup and must register the returned PID separately.

Only `:name` is forwarded; Wasmex-specific options such as `:bytes`, `:imports`, and `:wasi` are not passed through as GenServer options.

This complements #971, which separately corrects the public server typespecs.