### PR TITLE
Speed up CI builds and run Rust tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+  reviewers:
+  - tessi
 - package-ecosystem: mix
   directory: "/"
   schedule:

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -19,28 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cargo-component:
-    name: Prepare cargo-component
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache cargo-component
-        uses: actions/cache@v6
-        id: cargo-component
-        with:
-          path: ~/.cargo/bin/cargo-component
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-component-${{ env.CARGO_COMPONENT_VERSION }}
-
-      - uses: dtolnay/rust-toolchain@stable
-        if: steps.cargo-component.outputs.cache-hit != 'true'
-        with:
-          toolchain: 1.97.1
-
-      - name: Install cargo-component
-        if: steps.cargo-component.outputs.cache-hit != 'true'
-        run: cargo install --locked cargo-component --version "${CARGO_COMPONENT_VERSION}"
-
   test:
-    needs: cargo-component
     runs-on: ubuntu-latest
     name: OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }}
     strategy:
@@ -68,6 +47,11 @@ jobs:
         with:
           toolchain: 1.97.1
 
+      - name: Install cargo-component
+        uses: taiki-e/install-action@v2.79.11
+        with:
+          tool: cargo-component@${{ env.CARGO_COMPONENT_VERSION }}
+
       - name: Add targets
         run: |
           rustup target add wasm32-unknown-unknown
@@ -92,13 +76,6 @@ jobs:
             test/fixture_projects/wasm_link_import_test
             test/fixture_projects/wasm_link_test
             test/fixture_projects/wasm_test
-
-      - name: Restore cargo-component
-        uses: actions/cache/restore@v6
-        with:
-          path: ~/.cargo/bin/cargo-component
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-component-${{ env.CARGO_COMPONENT_VERSION }}
-          fail-on-cache-miss: true
 
       - name: Install Mix dependencies
         run: mix do deps.get + deps.compile

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -9,9 +9,38 @@ on:
 env:
   MIX_ENV: test
   WASMEX_BUILD: true
+  CARGO_COMPONENT_VERSION: 0.21.1
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  cargo-component:
+    name: Prepare cargo-component
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache cargo-component
+        uses: actions/cache@v6
+        id: cargo-component
+        with:
+          path: ~/.cargo/bin/cargo-component
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-component-${{ env.CARGO_COMPONENT_VERSION }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.cargo-component.outputs.cache-hit != 'true'
+        with:
+          toolchain: 1.97.1
+
+      - name: Install cargo-component
+        if: steps.cargo-component.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-component --version "${CARGO_COMPONENT_VERSION}"
+
   test:
+    needs: cargo-component
     runs-on: ubuntu-latest
     name: OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }}
     strategy:
@@ -26,8 +55,10 @@ jobs:
             elixir: 1.18.4
           - otp: 29.0.3
             elixir: 1.19.5
+          - otp: 29.0.3
+            elixir: 1.20.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
@@ -43,10 +74,34 @@ jobs:
           rustup target add wasm32-wasip1
           rustup target add wasm32-wasip2
 
-      - name: "Install cargo-component"
-        run: cargo install --locked cargo-component --version 0.21.1
-        shell: bash
+      - name: Cache Rust build dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: elixir-tests
+          add-job-id-key: false
+          cache-bin: false
+          save-if: ${{ matrix.otp == '28.5.0.3' && matrix.elixir == '1.20.2' }}
+          workspaces: |
+            native/wasmex
+            test/fixture_projects/component_exported_interface
+            test/fixture_projects/component_type_conversions
+            test/fixture_projects/guest_resource_component
+            test/fixture_projects/wasi_test
+            test/fixture_projects/wasm_import_test
+            test/fixture_projects/wasm_link_dep_test
+            test/fixture_projects/wasm_link_import_test
+            test/fixture_projects/wasm_link_test
+            test/fixture_projects/wasm_test
 
-      - run: mix do deps.get, deps.compile
+      - name: Restore cargo-component
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cargo/bin/cargo-component
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-component-${{ env.CARGO_COMPONENT_VERSION }}
+          fail-on-cache-miss: true
 
-      - run: mix test
+      - name: Install Mix dependencies
+        run: mix do deps.get + deps.compile
+
+      - name: Run tests
+        run: mix test

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -99,7 +99,10 @@ jobs:
             _build
           key: ${{ needs.deps.outputs.deps-cache-key }}
 
-      - run: mix docs
+      - name: Generate docs
+        run: mix docs
+        env:
+          WASMEX_BUILD: false
 
   test:
     needs: deps
@@ -147,16 +150,10 @@ jobs:
             test/fixture_projects/wasm_link_test
             test/fixture_projects/wasm_test
 
-      - name: Cache cargo-component
-        uses: actions/cache@v6
-        id: cargo-component
-        with:
-          path: ~/.cargo/bin/cargo-component
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-component-${{ env.CARGO_COMPONENT_VERSION }}
-
       - name: Install cargo-component
-        if: steps.cargo-component.outputs.cache-hit != 'true'
-        run: cargo install --locked cargo-component --version "${CARGO_COMPONENT_VERSION}"
+        uses: taiki-e/install-action@v2.79.11
+        with:
+          tool: cargo-component@${{ env.CARGO_COMPONENT_VERSION }}
 
       - name: Run tests
         run: mix test

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -99,10 +99,7 @@ jobs:
             _build
           key: ${{ needs.deps.outputs.deps-cache-key }}
 
-      - name: Generate docs
-        run: mix docs
-        env:
-          WASMEX_BUILD: false
+      - run: mix docs
 
   test:
     needs: deps

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -99,6 +99,29 @@ jobs:
             _build
           key: ${{ needs.deps.outputs.deps-cache-key }}
 
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
+
+      - name: Restore Rust build dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: elixir-tests
+          add-job-id-key: false
+          cache-bin: false
+          save-if: false
+          workspaces: |
+            native/wasmex
+            test/fixture_projects/component_exported_interface
+            test/fixture_projects/component_type_conversions
+            test/fixture_projects/guest_resource_component
+            test/fixture_projects/wasi_test
+            test/fixture_projects/wasm_import_test
+            test/fixture_projects/wasm_link_dep_test
+            test/fixture_projects/wasm_link_import_test
+            test/fixture_projects/wasm_link_test
+            test/fixture_projects/wasm_test
+
       - run: mix docs
 
   test:

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -11,6 +11,14 @@ env:
   OTP_VERSION: 29.0.3
   MIX_ENV: test
   WASMEX_BUILD: true
+  CARGO_COMPONENT_VERSION: 0.21.1
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deps:
@@ -18,7 +26,7 @@ jobs:
     outputs:
       deps-cache-key: ${{ steps.get-cache-key.outputs.key }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -31,7 +39,7 @@ jobs:
       - id: get-cache-key
         run: echo "key=mix-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ hashFiles('**/mix.lock') }}" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         id: cache-deps
         with:
           path: |
@@ -39,20 +47,20 @@ jobs:
             _build
           key: ${{ steps.get-cache-key.outputs.key }}
 
-      - run: mix do deps.get, deps.compile
+      - run: mix do deps.get + deps.compile
         if: steps.cache-deps.outputs.cache-hit != 'true'
 
   credo:
     needs: deps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         id: cache-deps
         with:
           path: |
@@ -63,10 +71,9 @@ jobs:
       - run: mix credo
 
   format:
-    needs: deps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -78,13 +85,13 @@ jobs:
     needs: deps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         id: cache-deps
         with:
           path: |
@@ -98,13 +105,13 @@ jobs:
     needs: deps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         id: cache-deps
         with:
           path: |
@@ -122,22 +129,34 @@ jobs:
           rustup target add wasm32-wasip1
           rustup target add wasm32-wasip2
 
-      - name: "Install cargo-component"
-        run: cargo install --locked cargo-component --version 0.21.1
-        shell: bash
-
-      - name: "Install wasm-tools"
-        run: cargo install --locked wasm-tools --version 1.254.0
-        shell: bash
-
-      - uses: actions/cache@v4
+      - name: Cache Rust build dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: elixir-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: elixir-tests
+          add-job-id-key: false
+          cache-bin: false
+          workspaces: |
+            native/wasmex
+            test/fixture_projects/component_exported_interface
+            test/fixture_projects/component_type_conversions
+            test/fixture_projects/guest_resource_component
+            test/fixture_projects/wasi_test
+            test/fixture_projects/wasm_import_test
+            test/fixture_projects/wasm_link_dep_test
+            test/fixture_projects/wasm_link_import_test
+            test/fixture_projects/wasm_link_test
+            test/fixture_projects/wasm_test
 
-      - run: mix test
+      - name: Cache cargo-component
+        uses: actions/cache@v6
+        id: cargo-component
+        with:
+          path: ~/.cargo/bin/cargo-component
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-component-${{ env.CARGO_COMPONENT_VERSION }}
+
+      - name: Install cargo-component
+        if: steps.cargo-component.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-component --version "${CARGO_COMPONENT_VERSION}"
+
+      - name: Run tests
+        run: mix test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
       - ".github/workflows/release.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build_release:
     name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Extract crate information
         shell: bash
@@ -82,13 +82,13 @@ jobs:
           cargo-args: ${{ matrix.job.cargo-args }}
 
       - name: Artifact upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build-crate.outputs.file-name }}
           path: ${{ steps.build-crate.outputs.file-path }}
 
       - name: Publish archives and packages
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             ${{ steps.build-crate.outputs.file-path }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - "native/wasmex/**"
+      - ".github/workflows/rust-ci.yml"
   push:
     branches:
       - main
     paths:
       - "native/wasmex/**"
+      - ".github/workflows/rust-ci.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -10,6 +10,13 @@ on:
     paths:
       - "native/wasmex/**"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: ./native/wasmex/
@@ -18,25 +25,25 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
           components: rustfmt, clippy
 
-      - uses: actions/cache@v4
+      - name: Cache Rust build dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: rust-cargo-${{ hashFiles('**/Cargo.lock') }}
+          workspaces: native/wasmex
 
-      - run: cargo fmt -- --check
+      - name: Check formatting
+        run: cargo fmt -- --check
 
-      - run: |
+      - name: Run tests
+        run: cargo test --all-targets --all-features
+
+      - name: Run Clippy
+        run: |
           touch src/lib.rs
           # need to disable extra_unused_lifetimes clippy because of rustler lifetime issues
           # https://github.com/rusterlium/rustler/issues/428

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ If you plan to change something on the Rust part of this project, set the follow
 
 I´m looking forward to your contributions. Please open a PR containing the motivation of your change. If it is a bigger change or refactoring, consider creating an issue first. We can discuss changes there first which might safe us time down the road :)
 
-Any changes should be covered by tests, they can be run with `mix test`.
+Run `WASMEX_BUILD=true mix test` for the Elixir integration suite and
+`cargo test --manifest-path native/wasmex/Cargo.toml --all-targets --all-features` for the Rust unit tests.
 In addition to tests, we expect the formatters and linters (`cargo fmt`, `cargo clippy`, `mix format`, `mix credo`) to pass.
 
 ## License


### PR DESCRIPTION
- install pinned `cargo-component` binaries in 2–3 seconds instead of compiling the tool from source
- cache Rust dependencies for the native crate, guest fixture projects, Rust CI, and docs
- remove the redundant OTP 29 / Elixir 1.20 compatibility job already covered by Elixir CI
- run the existing Rust unit tests in CI
- update GitHub Actions dependencies and add weekly Dependabot coverage for them
- cancel superseded runs and let formatting run without waiting for dependency setup

`cargo-component` does not publish upstream release binaries. The pinned installer uses the signed QuickInstall artifact when available and retains its source-install fallback.

## comparison

Steady-state PR timings compared with #975:

| Check | #975 | This PR | Change |
| --- | ---: | ---: | ---: |
| Compatibility wall time | 13m04s | 2m46s | -79% |
| Five retained compatibility jobs | 58m42s | 12m59s | -78% runner time |
| Primary Elixir test job | 12m55s | 1m59s | -85% |
| Docs job | 4m19s | 56s | -78% |
| Rust CI | 1m36s | 39s | -59%, while adding unit tests |

The 13-target NIF matrix completes in 47s–2m08s with warm caches. `cargo-component` installation itself takes 2–3 seconds instead of more than four minutes.