### PR TITLE
Include logo in Hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -55,6 +55,7 @@ defmodule Wasmex.MixProject do
         .formatter.exs
         mix.exs
         README.md
+        logo.svg
         LICENSE.md
         CHANGELOG.md
         ],


### PR DESCRIPTION
Include `logo.svg` in the Hex package file manifest so our docs look less sorrowful.